### PR TITLE
Typo in documentation

### DIFF
--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Field.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Field.java
@@ -46,7 +46,7 @@ public @interface Field {
   int length();
 
   /**
-   * @return The direction of the padding. Defaults to {@link Align#RIGHT}.
+   * @return The direction of the padding. Defaults to {@link Align#LEFT}.
    */
   Align align() default Align.LEFT;
 


### PR DESCRIPTION
Typo in documentation. Must be LEFT.