### PR TITLE
Repeating field support (@Field count)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,13 +24,13 @@ title: Changelog
   public List<String> getProductCodes() { return productCodes; }
   ```
 
-  The new `strictExportCount` attribute (default `true`) controls what happens when the
+  The new `strictCount` attribute (default `true`) controls what happens when the
   collection size does not match `count` at export time: `true` throws a
   `FixedFormatException`; `false` logs a warning and exports `min(count, actualSize)` elements.
 
   ```java
   // Lenient: export however many elements are present, up to count
-  @Field(offset = 1, length = 5, count = 3, strictExportCount = false)
+  @Field(offset = 1, length = 5, count = 3, strictCount = false)
   public List<String> getProductCodes() { return productCodes; }
   ```
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,41 @@ title: Changelog
 
 # Changelog
 
+## 1.5.1 (unreleased)
+
+### New features
+
+- **Repeating fields** — A single `@Field` annotation can now map consecutive same-format slots
+  in a record to a Java array or ordered `Collection` via the new `count` attribute.
+  Set `count` to the number of repetitions; the getter/setter must return `T[]`, `List<T>`,
+  `LinkedList<T>`, `Set<T>`, `SortedSet<T>`, or `Collection<T>`. Each slot occupies `length`
+  characters, starting at `offset + length * index`.
+
+  ```java
+  // Three 5-character product codes packed consecutively from position 1
+  @Field(offset = 1, length = 5, count = 3)
+  public String[] getProductCodes() { return productCodes; }
+
+  // Same field mapped to a List
+  @Field(offset = 1, length = 5, count = 3)
+  public List<String> getProductCodes() { return productCodes; }
+  ```
+
+  The new `strictExportCount` attribute (default `true`) controls what happens when the
+  collection size does not match `count` at export time: `true` throws a
+  `FixedFormatException`; `false` logs a warning and exports `min(count, actualSize)` elements.
+
+  ```java
+  // Lenient: export however many elements are present, up to count
+  @Field(offset = 1, length = 5, count = 3, strictExportCount = false)
+  public List<String> getProductCodes() { return productCodes; }
+  ```
+
+  See [Repeating fields](usage/annotations#repeating-fields) in the annotation reference and
+  [Example 7](examples#example-7--repeating-fields) for a full walkthrough.
+
+---
+
 ## 1.5.0 (2026-04-08)
 
 ### New features

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -323,6 +323,76 @@ System.out.println(manager.export(emp));
 
 **Conflict behaviour:** if `@Field` is present on both a field and its getter, an error is logged and the field annotation is used. It is recommended to annotate only one location.
 
+## Example 7 — Repeating fields
+
+Some fixed-width formats pack several consecutive slots of the same type into a single record — for example, a shipment record that lists up to four package weights in a row. Before 1.5.1 this required a separate `@Field` for each slot. With `count` you declare it once.
+
+**Scenario:** each line in a freight file holds a shipment ID (6 chars) followed by up to four package weights in grams, each stored as a 6-character right-aligned zero-padded integer. Unused trailing slots are `"000000"`.
+
+```
+// positions: 1-6 = shipment ID, 7-12 = weight 1, 13-18 = weight 2, 19-24 = weight 3, 25-30 = weight 4
+SHIP01002500010000000000000000
+```
+
+```java
+@Record
+public class ShipmentRecord {
+
+  private String shipmentId;
+  private List<Integer> packageWeights;
+
+  @Field(offset = 1, length = 6)
+  public String getShipmentId() { return shipmentId; }
+  public void setShipmentId(String shipmentId) { this.shipmentId = shipmentId; }
+
+  // Four consecutive 6-character integer slots starting at offset 7
+  @Field(offset = 7, length = 6, count = 4, align = Align.RIGHT, paddingChar = '0')
+  public List<Integer> getPackageWeights() { return packageWeights; }
+  public void setPackageWeights(List<Integer> packageWeights) { this.packageWeights = packageWeights; }
+}
+```
+
+```java
+FixedFormatManager manager = new FixedFormatManagerImpl();
+
+String line = "SHIP01002500010000000000000000";
+ShipmentRecord record = manager.load(ShipmentRecord.class, line);
+
+System.out.println(record.getShipmentId());      // "SHIP01"
+System.out.println(record.getPackageWeights());  // [2500, 1000, 0, 0]
+
+// Update the first two weights and export
+record.setPackageWeights(List.of(3200, 1800, 500, 0));
+System.out.println(manager.export(record));
+// "SHIP01003200001800000500000000"
+```
+
+**Using an array instead of a List:**
+
+```java
+@Field(offset = 7, length = 6, count = 4, align = Align.RIGHT, paddingChar = '0')
+public Integer[] getPackageWeights() { return packageWeights; }
+```
+
+**Lenient export — partial collection:**
+
+If the collection may have fewer elements than `count` (e.g. a shipment with only 2 packages), set `strictExportCount = false`. The remaining slots are left as the template value or untouched:
+
+```java
+@Field(offset = 7, length = 6, count = 4, align = Align.RIGHT, paddingChar = '0',
+       strictExportCount = false)
+public List<Integer> getPackageWeights() { return packageWeights; }
+```
+
+```java
+record.setPackageWeights(List.of(3200, 1800)); // only 2 of 4 slots provided
+System.out.println(manager.export(record));
+// "SHIP01003200001800[slots 3 and 4 unchanged from original record]"
+// Warning is logged: collection size (2) < count (4)
+```
+
+With `strictExportCount = true` (the default), passing a list of the wrong size throws a `FixedFormatException` at export time.
+
 ---
 
 [Home](index) | [Quick Start](quickstart) | [Usage](usage/) | [Get It](get-it) | [FAQ](faq)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -376,11 +376,11 @@ public Integer[] getPackageWeights() { return packageWeights; }
 
 **Lenient export — partial collection:**
 
-If the collection may have fewer elements than `count` (e.g. a shipment with only 2 packages), set `strictExportCount = false`. The remaining slots are left as the template value or untouched:
+If the collection may have fewer elements than `count` (e.g. a shipment with only 2 packages), set `strictCount = false`. The remaining slots are left as the template value or untouched:
 
 ```java
 @Field(offset = 7, length = 6, count = 4, align = Align.RIGHT, paddingChar = '0',
-       strictExportCount = false)
+       strictCount = false)
 public List<Integer> getPackageWeights() { return packageWeights; }
 ```
 
@@ -391,7 +391,7 @@ System.out.println(manager.export(record));
 // Warning is logged: collection size (2) < count (4)
 ```
 
-With `strictExportCount = true` (the default), passing a list of the wrong size throws a `FixedFormatException` at export time.
+With `strictCount = true` (the default), passing a list of the wrong size throws a `FixedFormatException` at export time.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ It is also straightforward to write and plug in your own formatters for custom d
 - Uses annotations as a clean way to instruct how your data should be read and written
 - Support for many built-in datatypes — no need to write format and parse routines
 - Handles signed numbers (e.g. `'-1000'` or `'1000-'` can be treated as negative 1000)
+- Repeating fields: map consecutive same-format slots to arrays or collections with a single `@Field(count = N)` annotation
 - Detailed error reporting when parsing fails
 
 ## Getting started

--- a/docs/usage/annotations.md
+++ b/docs/usage/annotations.md
@@ -62,7 +62,14 @@ Supported return types for `count > 1`: `T[]` (array), `List`, `LinkedList`, `Se
 
 ## @Fields
 
-Used on getter methods or directly on fields when a single field maps to more than one position in a string.
+Used on getter methods or directly on fields when a single property maps to **multiple
+non-uniform positions** in the same record — for example, a date field stored at two
+different offsets in two different formats.
+
+> **Note:** `@Fields` is only needed when the field positions or formats differ between
+> entries. For consecutive slots of the **same** length and format (e.g. three 5-character
+> codes in a row), use `@Field(count = N)` on a single getter instead — it is simpler and
+> less error-prone.
 
 | Attribute | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|

--- a/docs/usage/annotations.md
+++ b/docs/usage/annotations.md
@@ -28,6 +28,8 @@ When placed on a field, the manager derives the getter and setter by name conven
 | `align` | `Align` | no | `Align.LEFT` | How to align the field value when represented as a string. |
 | `paddingChar` | `char` | no | `' '` | The character to pad with when the length is longer than the field value. |
 | `formatter` | `Class<FixedFormatter>` | no | `ByTypeFormatter.class` | The formatter to use when reading and writing the field. |
+| `count` | `int` | no | `1` | Number of consecutive repetitions of this field. When greater than 1, the getter/setter must use an array or an ordered `Collection` (`List`, `Set`, `SortedSet`, etc.). Each repetition occupies `length` characters, starting at `offset + length * index`. |
+| `strictExportCount` | `boolean` | no | `true` | Only relevant when `count > 1`. If `true` (default), a size mismatch between the array/collection and `count` during export throws a `FixedFormatException`. If `false`, a warning is logged and export proceeds with `min(count, actualSize)` elements. |
 
 **Alignment values:**
 
@@ -37,6 +39,26 @@ When placed on a field, the manager derives the getter and setter by name conven
 | `Align.RIGHT` | Left | Left | Numeric fields — value ends at the right, padding fills the left |
 
 Example: a 5-character field with value `"Hi"` is stored as `"Hi   "` with `LEFT` and `"   Hi"` with `RIGHT`.
+
+### Repeating fields
+
+When a fixed-format record contains multiple consecutive slots of the same type, use `count` instead of listing individual `@Field` annotations manually:
+
+```java
+// Three 3-character product codes at positions 1–3, 4–6, 7–9
+@Field(offset = 1, length = 3, count = 3)
+public String[] getProductCodes() { return productCodes; }
+
+// Same with a List
+@Field(offset = 1, length = 3, count = 3)
+public List<String> getProductCodes() { return productCodes; }
+
+// Lenient export: log a warning instead of throwing when sizes differ
+@Field(offset = 1, length = 3, count = 3, strictExportCount = false)
+public String[] getProductCodes() { return productCodes; }
+```
+
+Supported return types for `count > 1`: `T[]` (array), `List`, `LinkedList`, `Set` (loaded as `LinkedHashSet`), `SortedSet` (loaded as `TreeSet`), `Collection`.
 
 ## @Fields
 

--- a/docs/usage/annotations.md
+++ b/docs/usage/annotations.md
@@ -29,7 +29,7 @@ When placed on a field, the manager derives the getter and setter by name conven
 | `paddingChar` | `char` | no | `' '` | The character to pad with when the length is longer than the field value. |
 | `formatter` | `Class<FixedFormatter>` | no | `ByTypeFormatter.class` | The formatter to use when reading and writing the field. |
 | `count` | `int` | no | `1` | Number of consecutive repetitions of this field. When greater than 1, the getter/setter must use an array or an ordered `Collection` (`List`, `Set`, `SortedSet`, etc.). Each repetition occupies `length` characters, starting at `offset + length * index`. |
-| `strictExportCount` | `boolean` | no | `true` | Only relevant when `count > 1`. If `true` (default), a size mismatch between the array/collection and `count` during export throws a `FixedFormatException`. If `false`, a warning is logged and export proceeds with `min(count, actualSize)` elements. |
+| `strictCount` | `boolean` | no | `true` | Only relevant when `count > 1`. If `true` (default), a size mismatch between the array/collection and `count` during export throws a `FixedFormatException`. If `false`, a warning is logged and export proceeds with `min(count, actualSize)` elements. |
 
 **Alignment values:**
 
@@ -54,7 +54,7 @@ public String[] getProductCodes() { return productCodes; }
 public List<String> getProductCodes() { return productCodes; }
 
 // Lenient export: log a warning instead of throwing when sizes differ
-@Field(offset = 1, length = 3, count = 3, strictExportCount = false)
+@Field(offset = 1, length = 3, count = 3, strictCount = false)
 public String[] getProductCodes() { return productCodes; }
 ```
 

--- a/fixedformat4j/pom.xml
+++ b/fixedformat4j/pom.xml
@@ -88,11 +88,11 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Lightweight SLF4J backend for tests only -->
+    <!-- Logback as SLF4J backend for tests — enables ListAppender for log capture -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>2.0.17</version>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.5.18</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Align.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Align.java
@@ -29,6 +29,7 @@ public enum Align {
    * Pad or chop data to the left, so the text is aligned to the right
    */
   RIGHT {
+    /** {@inheritDoc} */
     public String apply(String data, int length, char paddingChar) {
       String result;
       if (data == null) {
@@ -42,6 +43,7 @@ public enum Align {
       }
       return result;
     }
+    /** {@inheritDoc} */
     public String remove(String data, char paddingChar) {
       String result = data;
       if (data == null) {
@@ -58,6 +60,7 @@ public enum Align {
    * Pad or chop data to the right, so the text is aligned to the left
    */
   LEFT {
+    /** {@inheritDoc} */
     public String apply(String data, int length, char paddingChar) {
       String result;
       if (data == null) {
@@ -72,6 +75,7 @@ public enum Align {
       return result;
     }
 
+    /** {@inheritDoc} */
     public String remove(String data, char paddingChar) {
       String result = data;
       if (data == null) {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Align.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Align.java
@@ -47,7 +47,7 @@ public enum Align {
       if (data == null) {
         result = "";
       }
-      while (result.startsWith("" + paddingChar)) {
+      while (result.startsWith(String.valueOf(paddingChar))) {
         result = result.substring(1, result.length());
       }
       return result;
@@ -77,7 +77,7 @@ public enum Align {
       if (data == null) {
         result = "";
       }
-      while (result.endsWith("" + paddingChar)) {
+      while (result.endsWith(String.valueOf(paddingChar))) {
         result = result.substring(0, result.length()-1);
       }
       return result;

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Align.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Align.java
@@ -20,7 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 /**
  * Capable of pad or chop data in a given direction
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public enum Align {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Field.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Field.java
@@ -85,6 +85,6 @@ public @interface Field {
    *
    * @return whether to throw on size mismatch during export
    */
-  boolean strictExportCount() default true;
+  boolean strictCount() default true;
 
 }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Field.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Field.java
@@ -58,4 +58,26 @@ public @interface Field {
 
   Class<? extends FixedFormatter<?>> formatter() default ByTypeFormatter.class;
 
+  /**
+   * Number of consecutive repetitions of this field.
+   * When greater than 1, the getter/setter must use an array or an ordered {@link java.util.Collection}
+   * (e.g. {@code List}, {@code Set}, {@code SortedSet}). Each repetition occupies
+   * {@code length} characters, starting at {@code offset + length * index}.
+   *
+   * @return the repetition count, must be &gt;= 1
+   */
+  int count() default 1;
+
+  /**
+   * Controls export behaviour when the actual collection/array size differs from {@link #count()}.
+   * Only relevant when {@link #count()} &gt; 1.
+   * <ul>
+   *   <li>{@code true} (default) — throws a {@link com.ancientprogramming.fixedformat4j.exception.FixedFormatException}</li>
+   *   <li>{@code false} — logs a warning and exports {@code min(count, actualSize)} elements</li>
+   * </ul>
+   *
+   * @return whether to throw on size mismatch during export
+   */
+  boolean strictExportCount() default true;
+
 }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Field.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Field.java
@@ -26,7 +26,7 @@ import java.lang.annotation.RetentionPolicy;
 /**
  * This annotation descibes how a setter/getter pairs should be formatted by the fixedFormatManager.
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Field.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Field.java
@@ -56,6 +56,13 @@ public @interface Field {
    */
   char paddingChar() default ' ';
 
+  /**
+   * The formatter class to use for this field.
+   * Defaults to {@link ByTypeFormatter}, which selects the formatter automatically based on the
+   * getter's return type. Override only when custom formatting logic is required.
+   *
+   * @return the formatter class
+   */
   Class<? extends FixedFormatter<?>> formatter() default ByTypeFormatter.class;
 
   /**

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Fields.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Fields.java
@@ -22,7 +22,7 @@ import java.lang.annotation.Target;
 
 /**
  * Wrapper for more than one field.
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/FixedFormatBoolean.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/FixedFormatBoolean.java
@@ -23,7 +23,7 @@ import java.lang.annotation.ElementType;
 /**
  * Define representations for {@link Boolean#TRUE} and {@link Boolean#FALSE}
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/FixedFormatDecimal.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/FixedFormatDecimal.java
@@ -35,12 +35,34 @@ public @interface FixedFormatDecimal {
   public static final char DECIMAL_DELIMITER = '.';
   public static final int ROUNDING_MODE = BigDecimal.ROUND_HALF_UP;
 
+  /**
+   * The number of decimal places to use when formatting or parsing the value.
+   *
+   * @return the number of decimal places; defaults to {@value #DECIMALS}
+   */
   int decimals() default DECIMALS;
 
+  /**
+   * Whether to include an explicit decimal delimiter character in the formatted string.
+   * When {@code false} (the default), the decimal point is implicit and determined by {@link #decimals()}.
+   *
+   * @return {@code true} to use an explicit delimiter; defaults to {@value #USE_DECIMAL_DELIMITER}
+   */
   boolean useDecimalDelimiter() default USE_DECIMAL_DELIMITER;
 
+  /**
+   * The character used as the decimal delimiter when {@link #useDecimalDelimiter()} is {@code true}.
+   *
+   * @return the decimal delimiter character; defaults to {@value #DECIMAL_DELIMITER}
+   */
   char decimalDelimiter() default DECIMAL_DELIMITER;
 
+  /**
+   * The rounding mode to apply when scaling the value to the configured number of {@link #decimals()}.
+   * Uses the {@link java.math.BigDecimal} rounding-mode constants (e.g. {@code BigDecimal.ROUND_HALF_UP}).
+   *
+   * @return the rounding mode constant; defaults to {@code BigDecimal.ROUND_HALF_UP}
+   */
   int roundingMode() default ROUNDING_MODE;
   
 }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/FixedFormatDecimal.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/FixedFormatDecimal.java
@@ -22,7 +22,7 @@ import java.lang.annotation.Target;
 import java.math.BigDecimal;
 
 /**
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/FixedFormatNumber.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/FixedFormatNumber.java
@@ -37,9 +37,24 @@ public @interface FixedFormatNumber {
   public static final char DEFAULT_NEGATIVE_SIGN = '-';
 
 
+  /**
+   * The sign strategy controlling where the sign character is placed in the formatted field.
+   *
+   * @return the {@link Sign} mode; defaults to {@link Sign#NOSIGN}
+   */
   Sign sign() default Sign.NOSIGN;
 
+  /**
+   * The character used to represent a positive number when {@link #sign()} is active.
+   *
+   * @return the positive sign character; defaults to {@value #DEFAULT_POSITIVE_SIGN}
+   */
   char positiveSign() default DEFAULT_POSITIVE_SIGN;
 
+  /**
+   * The character used to represent a negative number when {@link #sign()} is active.
+   *
+   * @return the negative sign character; defaults to {@value #DEFAULT_NEGATIVE_SIGN}
+   */
   char negativeSign() default DEFAULT_NEGATIVE_SIGN;
 }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/FixedFormatNumber.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/FixedFormatNumber.java
@@ -21,7 +21,7 @@ import java.lang.annotation.Target;
 import java.lang.annotation.ElementType;
 
 /**
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.1.0
  */
 

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/FixedFormatPattern.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/FixedFormatPattern.java
@@ -24,7 +24,7 @@ import java.lang.annotation.ElementType;
  * Used together with FixedFormatField annotations to provide a pattern for the data.
  * This annotation is required for {@link java.util.Date} datatype.
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Record.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Record.java
@@ -23,7 +23,7 @@ import java.lang.annotation.ElementType;
 /**
  * Marks a class as a representation of a fixed format record
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Sign.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Sign.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.StringUtils;
  * Sign defines where to place a sign defining a positive or negative number.
  * Is to be used in formatters operating numbers.
  * 
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.1.0
  */
 public enum Sign {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Sign.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Sign.java
@@ -32,10 +32,12 @@ public enum Sign {
    * This just delegate to the {@link Align} defined in {@link FormatInstructions}.
    */
   NOSIGN {
+    /** {@inheritDoc} */
     public String apply(String value, FormatInstructions instructions) {
       return instructions.getAlignment().apply(value, instructions.getLength(), instructions.getPaddingChar());
     }
 
+    /** {@inheritDoc} */
     public String remove(String value, FormatInstructions instructions) {
       String result =  instructions.getAlignment().remove(value, instructions.getPaddingChar());
       if (StringUtils.isEmpty(result)) {
@@ -50,6 +52,7 @@ public enum Sign {
    * Prepend the sign to the string
    */
   PREPEND {
+    /** {@inheritDoc} */
     public String apply(String value, FormatInstructions instructions) {
       String sign = StringUtils.substring(value, 0, 1);
       if ("-".equals(sign)) {
@@ -61,6 +64,7 @@ public enum Sign {
       return sign + StringUtils.substring(result, 1);
     }
 
+    /** {@inheritDoc} */
     public String remove(String value, FormatInstructions instructions) {
       String sign = StringUtils.substring(value, 0, 1);
       String valueWithoutSign = StringUtils.substring(value, 1);
@@ -80,6 +84,7 @@ public enum Sign {
    * Append the sign to the string
    */
   APPEND {
+    /** {@inheritDoc} */
     public String apply(String value, FormatInstructions instructions) {
       String sign = StringUtils.substring(value, 0, 1);
       if ("-".equals(sign)) {
@@ -91,6 +96,7 @@ public enum Sign {
       return StringUtils.substring(result, 1) + sign;
 
     }
+    /** {@inheritDoc} */
     public String remove(String value, FormatInstructions instructions) {
       String sign = StringUtils.substring(value, value.length()-1);
       String valueWithoutSign = StringUtils.substring(value, 0, value.length()-1);
@@ -122,7 +128,22 @@ public enum Sign {
   }
 
 
+  /**
+   * Applies the sign to {@code value} according to this strategy, padding the result to the
+   * length specified in {@code instructions}.
+   *
+   * @param value        the raw numeric string (may include a leading {@code -})
+   * @param instructions the formatting instructions for the field
+   * @return the sign-formatted string padded to the required length
+   */
   public abstract String apply(String value, FormatInstructions instructions);
 
+  /**
+   * Strips the sign character from {@code value} and returns the bare numeric string.
+   *
+   * @param value        the field value as read from the fixed-width record
+   * @param instructions the formatting instructions for the field
+   * @return the numeric string with the sign and padding removed
+   */
   public abstract String remove(String value, FormatInstructions instructions);
 }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/exception/FixedFormatException.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/exception/FixedFormatException.java
@@ -18,7 +18,7 @@ package com.ancientprogramming.fixedformat4j.exception;
 /**
  * Thrown when errors occur while loading or exporting data.
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class FixedFormatException extends RuntimeException {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/exception/FixedFormatException.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/exception/FixedFormatException.java
@@ -23,10 +23,21 @@ package com.ancientprogramming.fixedformat4j.exception;
  */
 public class FixedFormatException extends RuntimeException {
 
+  /**
+   * Creates a new exception with the given detail message.
+   *
+   * @param s the detail message
+   */
   public FixedFormatException(String s) {
     super(s);
   }
 
+  /**
+   * Creates a new exception with the given detail message and cause.
+   *
+   * @param s         the detail message
+   * @param throwable the cause
+   */
   public FixedFormatException(String s, Throwable throwable) {
     super(s, throwable);
   }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/AbstractFixedFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/AbstractFixedFormatter.java
@@ -22,6 +22,13 @@ package com.ancientprogramming.fixedformat4j.format;
  * @since 1.0.0
  */
 public abstract class AbstractFixedFormatter<T> implements FixedFormatter<T> {
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Strips padding from {@code value} according to the alignment and padding char defined in
+   * {@code instructions}, then delegates to {@link #asObject(String, FormatInstructions)}.
+   * Returns {@code null} when {@code value} is {@code null}.
+   */
   public T parse(String value, FormatInstructions instructions) {
     T result = null;
     if (value != null) {
@@ -41,11 +48,33 @@ public abstract class AbstractFixedFormatter<T> implements FixedFormatter<T> {
     return instructions.getAlignment().remove(value, instructions.getPaddingChar());
   }
 
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Converts {@code value} to its string representation via
+   * {@link #asString(Object, FormatInstructions)}, then applies padding and alignment as defined
+   * in {@code instructions}.
+   */
   public String format(T value, FormatInstructions instructions) {
     return instructions.getAlignment().apply(asString(value, instructions), instructions.getLength(), instructions.getPaddingChar());
   }
 
+  /**
+   * Converts the trimmed string {@code string} to an instance of {@code T}.
+   * Padding has already been removed from {@code string} before this method is called.
+   *
+   * @param string       the raw (padding-stripped) field value
+   * @param instructions formatting instructions for the field
+   * @return the parsed value, or {@code null} if the field is empty
+   */
   public abstract T asObject(String string, FormatInstructions instructions);
 
+  /**
+   * Converts {@code obj} to its raw string representation before padding is applied.
+   *
+   * @param obj          the value to convert; may be {@code null}
+   * @param instructions formatting instructions for the field
+   * @return the string representation of {@code obj}
+   */
   public abstract String asString(T obj, FormatInstructions instructions);
 }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/AbstractFixedFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/AbstractFixedFormatter.java
@@ -18,7 +18,7 @@ package com.ancientprogramming.fixedformat4j.format;
 /**
  * Handles default formatting and parsing based on FixedFormatAnnotation values.
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public abstract class AbstractFixedFormatter<T> implements FixedFormatter<T> {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FixedFormatManager.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FixedFormatManager.java
@@ -22,7 +22,7 @@ import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
  * <p>
  * A <code>FixedFormatManager</code> is associated with one type of fixed format data.
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public interface FixedFormatManager {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FixedFormatManager.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FixedFormatManager.java
@@ -30,32 +30,39 @@ public interface FixedFormatManager {
   /**
    * Create an instance of the fixedFormatClass and load the data string into the object according to the annotations.
    *
-   * @param clazz the class to instanciate
+   * @param clazz the class to instantiate
    * @param data  the data to load
+   * @param <T>   the type of the record class
    * @return an object loaded with the fixedformat data
-   * @throws ParseException       in case that some specific parsing fails. Ex. a field could't be parsed according to some annotation instructions.
+   * @throws ParseException       in case that some specific parsing fails. Ex. a field couldn't be parsed according to some annotation instructions.
    *                              This exception contains detailed information telling what failed to be loaded.
-   * @throws FixedFormatException in case the fixedFormatRecord class cannot be loaded. Ex. the Class wasn't annotated with a @Record annotation
+   * @throws FixedFormatException in case the fixedFormatRecord class cannot be loaded. Ex. the Class wasn't annotated with a {@code @Record} annotation
    */
   <T> T load(Class<T> clazz, String data) throws FixedFormatException;
 
   /**
-   * Exports the instance &lt;T&gt; into a fixed formatted string representation.
-   * The instance has to be @Record annotated and containing @Field annotations on the getters that is to be exported
-   * @param instance is he object that is to be exported
-   * @param <T> the type of the instance to export
-   * @return a string representation of the instance after all of it�s @Field annotated data was exported
+   * Exports {@code instance} into a fixed-width string representation.
+   * The instance must be annotated with {@code @Record} and have {@code @Field} annotations on
+   * the getters that are to be exported.
+   *
+   * @param instance the object to export
+   * @param <T>      the type of the instance to export
+   * @return a fixed-width string built from all {@code @Field}-annotated getters of {@code instance}
    * @throws FixedFormatException in case the instance couldn't be exported
    */
   <T> String export(T instance) throws FixedFormatException;
 
   /**
-   * Exports the instance &lt;T&gt; into a fixed formatted string representation.
-   * The instance is merged on top of the given <code>data</code>.
-   * It is handy in cases where a lot of the data is static. Then the data can be used as a template
-   * @param template the data to merge the exported instance with
-   * @param instance is he object that is to be exported
-   * @return a string representation of the instance after all of it�s @Field annotated data was merged on to the given <code>template</code>
+   * Exports {@code instance} into a fixed-width string representation, merging it on top of
+   * {@code template}.
+   * <p>
+   * This is useful when most of a record's content is static: supply the static content as
+   * {@code template} and only the dynamic fields will be overwritten.
+   *
+   * @param template the base string to merge the exported instance into
+   * @param instance the object to export
+   * @param <T>      the type of the instance to export
+   * @return a fixed-width string with all {@code @Field}-annotated values merged into {@code template}
    * @throws FixedFormatException in case the instance couldn't be exported
    */
   <T> String export(String template, T instance) throws FixedFormatException;

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FixedFormatUtil.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FixedFormatUtil.java
@@ -32,11 +32,14 @@ public class FixedFormatUtil {
   private static final Logger LOG = LoggerFactory.getLogger(FixedFormatUtil.class);
 
   /**
-   * Fetch data from the record string according to the {@link FormatInstructions} and {@link FormatContext}
-   * @param record the string to fetch from
-   * @param instructions the fixed
-   * @param context the context to fetch data in
-   * @return the String data fetched from the record. Can be <code>null</code> if the record was shorter than the context expected
+   * Fetches the slice of {@code record} that corresponds to the field described by
+   * {@code instructions} and {@code context}.
+   *
+   * @param record       the full fixed-width record string
+   * @param instructions the field's formatting instructions (supplies the field length)
+   * @param context      the format context (supplies the 1-based field offset)
+   * @return the extracted field substring, or {@code null} if {@code record} is shorter than
+   *         the requested offset
    */
   public static String fetchData(String record, FormatInstructions instructions, FormatContext<?> context) {
     String result;
@@ -60,6 +63,16 @@ public class FixedFormatUtil {
     return result;
   }
 
+  /**
+   * Creates an instance of the given {@code formatterClass}, first trying a single-argument
+   * constructor that accepts a {@link FormatContext}, then falling back to a no-arg constructor.
+   *
+   * @param formatterClass the formatter class to instantiate
+   * @param context        the {@link FormatContext} passed to the single-argument constructor attempt
+   * @param <T>            the value type handled by the formatter
+   * @return a ready-to-use formatter instance
+   * @throws FixedFormatException if neither constructor is available
+   */
   public static <T> FixedFormatter<T> getFixedFormatterInstance(Class<? extends FixedFormatter<T>> formatterClass, FormatContext<?> context) {
     FixedFormatter<T> formatter = getFixedFormatterInstance(formatterClass, context.getClass(), context);
     if (formatter == null) {
@@ -71,6 +84,18 @@ public class FixedFormatUtil {
     return formatter;
   }
 
+  /**
+   * Creates an instance of {@code formatterClass} using either a single-argument constructor
+   * (when both {@code paramType} and {@code paramValue} are non-null) or a no-arg constructor.
+   * Returns {@code null} when the requested constructor does not exist.
+   *
+   * @param formatterClass the formatter class to instantiate
+   * @param paramType      the constructor parameter type; {@code null} to force the no-arg path
+   * @param paramValue     the constructor argument value; {@code null} to force the no-arg path
+   * @param <T>            the value type handled by the formatter
+   * @return a formatter instance, or {@code null} if the matching constructor is absent
+   * @throws FixedFormatException if a matching constructor exists but instantiation fails
+   */
   public static <T> FixedFormatter<T> getFixedFormatterInstance(Class<? extends FixedFormatter<T>> formatterClass, Class<?> paramType, FormatContext<?> paramValue) {
     FixedFormatter<T> result;
     if (paramType != null && paramValue != null) {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FixedFormatUtil.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FixedFormatUtil.java
@@ -66,7 +66,7 @@ public class FixedFormatUtil {
       formatter = getFixedFormatterInstance(formatterClass, null, null);
     }
     if (formatter == null) {
-      throw new FixedFormatException("could not create instance of [" + formatterClass.getName() + "] because the class has no default constructor and no constructor with " + FormatContext.class.getName() + " as argument.");
+      throw new FixedFormatException(format("could not create instance of [%s] because the class has no default constructor and no constructor with %s as argument.", formatterClass.getName(), FormatContext.class.getName()));
     }
     return formatter;
   }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FixedFormatUtil.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FixedFormatUtil.java
@@ -24,7 +24,7 @@ import static java.lang.String.format;
 /**
  * Utility class used when loading and exporting to and from fixedformat data.
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class FixedFormatUtil {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FixedFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FixedFormatter.java
@@ -26,7 +26,7 @@ import com.ancientprogramming.fixedformat4j.format.impl.DateFormatter;
  * <p>
  * Example: <p><code>@Field(offset = 1, length = 20, formatter = {@link DateFormatter}.class)</code></p>
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public interface FixedFormatter<T> {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FormatContext.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FormatContext.java
@@ -48,10 +48,6 @@ public class FormatContext<T> {
 
 
   public String toString() {
-    return "FormatContext{" +
-        "offset=" + offset +
-        ", dataType=" + dataType.getName() +
-        ", formatter=" + formatter.getName() +
-        '}';
+    return String.format("FormatContext{offset=%d, dataType=%s, formatter=%s}", offset, dataType.getName(), formatter.getName());
   }
 }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FormatContext.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FormatContext.java
@@ -28,20 +28,42 @@ public class FormatContext<T> {
   private Class<T> dataType;
   private Class<? extends FixedFormatter<T>> formatter;
 
+  /**
+   * Creates a new format context.
+   *
+   * @param offset    the 1-based character offset of the field within the record
+   * @param dataType  the Java type of the field value
+   * @param formatter the formatter class to use for this field
+   */
   public FormatContext(int offset, Class<T> dataType, Class<? extends FixedFormatter<T>> formatter) {
     this.offset = offset;
     this.dataType = dataType;
     this.formatter = formatter;
   }
 
+  /**
+   * Returns the 1-based character offset of the field within the record.
+   *
+   * @return the field offset
+   */
   public int getOffset() {
     return offset;
   }
 
+  /**
+   * Returns the Java type of the field value.
+   *
+   * @return the data type class
+   */
   public Class<T> getDataType() {
     return dataType;
   }
 
+  /**
+   * Returns the formatter class responsible for parsing and formatting this field.
+   *
+   * @return the formatter class
+   */
   public Class<? extends FixedFormatter<T>> getFormatter() {
     return formatter;
   }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FormatContext.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FormatContext.java
@@ -19,7 +19,7 @@ package com.ancientprogramming.fixedformat4j.format;
  * Contains context for loading and exporting fixedformat data.
  * The context describes what kind of formatter to use, what datatype to convert and what offset to fetch data from.
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class FormatContext<T> {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FormatInstructions.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FormatInstructions.java
@@ -24,7 +24,7 @@ import com.ancientprogramming.fixedformat4j.format.data.FixedFormatNumberData;
 /**
  * Contains instructions on how to export and load fixed formatted data.
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class FormatInstructions {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FormatInstructions.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FormatInstructions.java
@@ -37,6 +37,17 @@ public class FormatInstructions {
   private FixedFormatNumberData fixedFormatNumberData;
   private FixedFormatDecimalData fixedFormatDecimalData;
 
+  /**
+   * Creates a fully-populated set of format instructions.
+   *
+   * @param length                  the fixed width of the field in characters
+   * @param alignment               the alignment strategy used to pad and strip the field
+   * @param paddingChar             the character used for padding
+   * @param fixedFormatPatternData  date/time pattern configuration, or {@code null} if unused
+   * @param fixedFormatBooleanData  boolean value configuration, or {@code null} if unused
+   * @param fixedFormatNumberData   number sign configuration, or {@code null} if unused
+   * @param fixedFormatDecimalData  decimal precision configuration, or {@code null} if unused
+   */
   public FormatInstructions(int length, Align alignment, char paddingChar, FixedFormatPatternData fixedFormatPatternData, FixedFormatBooleanData fixedFormatBooleanData, FixedFormatNumberData fixedFormatNumberData, FixedFormatDecimalData fixedFormatDecimalData) {
     this.length = length;
     this.alignment = alignment;
@@ -47,30 +58,65 @@ public class FormatInstructions {
     this.fixedFormatDecimalData = fixedFormatDecimalData;
   }
 
+  /**
+   * Returns the fixed character width of the field.
+   *
+   * @return the field length in characters
+   */
   public int getLength() {
     return length;
   }
 
+  /**
+   * Returns the alignment strategy used to pad and strip the field value.
+   *
+   * @return the {@link Align} constant for this field
+   */
   public Align getAlignment() {
     return alignment;
   }
 
+  /**
+   * Returns the character used to pad the field to its full length.
+   *
+   * @return the padding character
+   */
   public char getPaddingChar() {
     return paddingChar;
   }
 
+  /**
+   * Returns the date/time pattern configuration for this field.
+   *
+   * @return the {@link FixedFormatPatternData}, or {@code null} if no pattern annotation is present
+   */
   public FixedFormatPatternData getFixedFormatPatternData() {
     return fixedFormatPatternData;
   }
 
+  /**
+   * Returns the boolean value configuration for this field.
+   *
+   * @return the {@link FixedFormatBooleanData}, or {@code null} if no boolean annotation is present
+   */
   public FixedFormatBooleanData getFixedFormatBooleanData() {
     return fixedFormatBooleanData;
   }
 
+  /**
+   * Returns the decimal precision configuration for this field.
+   *
+   * @return the {@link FixedFormatDecimalData}, or {@code null} if no decimal annotation is present
+   */
   public FixedFormatDecimalData getFixedFormatDecimalData() {
     return fixedFormatDecimalData;
   }
 
+  /**
+   * Returns the number sign configuration for this field.
+   *
+   * @return the {@link FixedFormatNumberData}, or {@code null} if no number annotation is present
+   */
   public FixedFormatNumberData getFixedFormatNumberData() {
     return fixedFormatNumberData;
   }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FormatInstructions.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FormatInstructions.java
@@ -76,14 +76,7 @@ public class FormatInstructions {
   }
 
   public String toString() {
-    return "FormatInstructions{" +
-        "length=" + length +
-        ", alignment=" + alignment +
-        ", paddingChar='" + paddingChar + "'" + 
-        ", fixedFormatPatternData=" + fixedFormatPatternData +
-        ", fixedFormatBooleanData=" + fixedFormatBooleanData +
-        ", fixedFormatNumberData=" + fixedFormatNumberData +
-        ", fixedFormatDecimalData=" + fixedFormatDecimalData +
-        '}';
+    return String.format("FormatInstructions{length=%d, alignment=%s, paddingChar='%c', fixedFormatPatternData=%s, fixedFormatBooleanData=%s, fixedFormatNumberData=%s, fixedFormatDecimalData=%s}",
+        length, alignment, paddingChar, fixedFormatPatternData, fixedFormatBooleanData, fixedFormatNumberData, fixedFormatDecimalData);
   }
 }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/ParseException.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/ParseException.java
@@ -45,7 +45,9 @@ public class ParseException extends FixedFormatException {
    * @param cause the reason why the data couldn't be parsed
    */
   public ParseException(String completeText, String failedText, Class<?> annotatedClass, Method annotatedMethod, FormatContext<?> formatContext, FormatInstructions formatInstructions, Throwable cause) {
-    super("Failed to parse '" + failedText + "' at offset " + formatContext.getOffset() + " as " + formatContext.getDataType().getName() + " from '" + completeText + "'. Got format instructions from " + annotatedClass.getName() + "." + annotatedMethod.getName() + ". See details{" + formatContext.toString() + ", " +formatInstructions.toString() + "}", cause);
+    super(String.format("Failed to parse '%s' at offset %d as %s from '%s'. Got format instructions from %s.%s. See details{%s, %s}",
+        failedText, formatContext.getOffset(), formatContext.getDataType().getName(), completeText,
+        annotatedClass.getName(), annotatedMethod.getName(), formatContext, formatInstructions), cause);
      this.completeText = completeText;
     this.failedText = failedText;
     this.annotatedClass = annotatedClass;

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/ParseException.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/ParseException.java
@@ -22,7 +22,7 @@ import java.lang.reflect.Method;
 /**
  * Used in cases where data couldn't be parse according to the {@link FormatContext} and {@link FormatInstructions}.
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.2.0
  */
 public class ParseException extends FixedFormatException {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatBooleanData.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatBooleanData.java
@@ -32,15 +32,32 @@ public class FixedFormatBooleanData {
 
   private String falseValue;
 
+  /**
+   * Creates a boolean data object with the given string representations for {@code true} and
+   * {@code false}.
+   *
+   * @param trueValue  the string that represents a {@code true} value in the fixed-width field
+   * @param falseValue the string that represents a {@code false} value in the fixed-width field
+   */
   public FixedFormatBooleanData(String trueValue, String falseValue) {
     this.trueValue = trueValue;
     this.falseValue = falseValue;
   }
 
+  /**
+   * Returns the string representation of {@code true} for this field.
+   *
+   * @return the true-value string
+   */
   public String getTrueValue() {
     return trueValue;
   }
 
+  /**
+   * Returns the string representation of {@code false} for this field.
+   *
+   * @return the false-value string
+   */
   public String getFalseValue() {
     return falseValue;
   }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatBooleanData.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatBooleanData.java
@@ -47,9 +47,6 @@ public class FixedFormatBooleanData {
 
 
   public String toString() {
-    return "FixedFormatBooleanData{" +
-        "trueValue='" + trueValue + "'" +
-        ", falseValue='" + falseValue + "'" +
-        '}';
+    return String.format("FixedFormatBooleanData{trueValue='%s', falseValue='%s'}", trueValue, falseValue);
   }
 }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatBooleanData.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatBooleanData.java
@@ -21,7 +21,7 @@ import static com.ancientprogramming.fixedformat4j.annotation.FixedFormatBoolean
 /**
  * Data object containing the exact same data as {@link FixedFormatBoolean} 
   *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class FixedFormatBooleanData {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatDecimalData.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatDecimalData.java
@@ -60,11 +60,7 @@ public class FixedFormatDecimalData {
   }
 
   public String toString() {
-    return "FixedFormatDecimalData{" +
-        "decimals=" + decimals +
-        ", useDecimalDelimiter=" + useDecimalDelimiter +
-        ", decimalDelimiter='" + decimalDelimiter + "'" + 
-        ", roundingMode='" + roundingMode + "'" + 
-        '}';
+    return String.format("FixedFormatDecimalData{decimals=%d, useDecimalDelimiter=%b, decimalDelimiter='%c', roundingMode='%s'}",
+        decimals, useDecimalDelimiter, decimalDelimiter, roundingMode);
   }
 }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatDecimalData.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatDecimalData.java
@@ -36,6 +36,14 @@ public class FixedFormatDecimalData {
   
   public static final FixedFormatDecimalData DEFAULT = new FixedFormatDecimalData(DECIMALS, USE_DECIMAL_DELIMITER, DECIMAL_DELIMITER, RoundingMode.valueOf(ROUNDING_MODE));
 
+  /**
+   * Creates a decimal data object.
+   *
+   * @param decimals             the number of decimal places
+   * @param useDecimalDelimiter  {@code true} to include an explicit decimal delimiter in the field
+   * @param decimalDelimiter     the delimiter character used when {@code useDecimalDelimiter} is {@code true}
+   * @param roundingMode         the rounding mode applied when scaling the value
+   */
   public FixedFormatDecimalData(int decimals, boolean useDecimalDelimiter, char decimalDelimiter, RoundingMode roundingMode) {
     this.decimals = decimals;
     this.useDecimalDelimiter = useDecimalDelimiter;
@@ -43,18 +51,38 @@ public class FixedFormatDecimalData {
     this.roundingMode = roundingMode;
   }
 
+  /**
+   * Returns the number of decimal places.
+   *
+   * @return the decimal count
+   */
   public int getDecimals() {
     return decimals;
   }
 
+  /**
+   * Returns whether an explicit decimal delimiter character is included in the formatted value.
+   *
+   * @return {@code true} if a delimiter is used; {@code false} for implicit decimals
+   */
   public boolean isUseDecimalDelimiter() {
     return useDecimalDelimiter;
   }
 
+  /**
+   * Returns the decimal delimiter character.
+   *
+   * @return the delimiter character (only meaningful when {@link #isUseDecimalDelimiter()} is {@code true})
+   */
   public char getDecimalDelimiter() {
     return decimalDelimiter;
   }
 
+  /**
+   * Returns the rounding mode applied when scaling to the configured number of decimal places.
+   *
+   * @return the {@link RoundingMode}
+   */
   public RoundingMode getRoundingMode() {
     return roundingMode;
   }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatDecimalData.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatDecimalData.java
@@ -24,7 +24,7 @@ import static com.ancientprogramming.fixedformat4j.annotation.FixedFormatDecimal
 /**
  * Data object containing the exact same data as {@link FixedFormatDecimal}
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class FixedFormatDecimalData {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatNumberData.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatNumberData.java
@@ -31,21 +31,42 @@ public class FixedFormatNumberData {
   private char positiveSign;
   private char negativeSign;
 
+  /**
+   * Creates a number data object.
+   *
+   * @param signing      the sign strategy controlling where the sign character appears
+   * @param positiveSign the character used to represent a positive number
+   * @param negativeSign the character used to represent a negative number
+   */
   public FixedFormatNumberData(Sign signing, char positiveSign, char negativeSign) {
     this.signing = signing;
     this.positiveSign = positiveSign;
     this.negativeSign = negativeSign;
   }
 
-  
+  /**
+   * Returns the sign strategy for this field.
+   *
+   * @return the {@link Sign} mode
+   */
   public Sign getSigning() {
     return signing;
   }
 
+  /**
+   * Returns the character used to represent a positive number.
+   *
+   * @return the positive sign character
+   */
   public Character getPositiveSign() {
     return positiveSign;
   }
 
+  /**
+   * Returns the character used to represent a negative number.
+   *
+   * @return the negative sign character
+   */
   public Character getNegativeSign() {
     return negativeSign;
   }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatNumberData.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatNumberData.java
@@ -52,10 +52,6 @@ public class FixedFormatNumberData {
 
 
   public String toString() {
-    return "FixedFormatNumberData{" +
-        "signing=" + signing +
-        ", positiveSign='" + positiveSign + "'" +
-        ", negativeSign='" + negativeSign + "'" + 
-        '}';
+    return String.format("FixedFormatNumberData{signing=%s, positiveSign='%c', negativeSign='%c'}", signing, positiveSign, negativeSign);
   }
 }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatNumberData.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatNumberData.java
@@ -20,7 +20,7 @@ import static com.ancientprogramming.fixedformat4j.annotation.FixedFormatNumber.
 /**
  * Data object containing the exact same data as {@link com.ancientprogramming.fixedformat4j.annotation.FixedFormatNumber}
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.1.0
  */
 public class FixedFormatNumberData {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatPatternData.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatPatternData.java
@@ -21,7 +21,7 @@ import static com.ancientprogramming.fixedformat4j.annotation.FixedFormatPattern
 /**
  * Data object containing the exact same data as {@link FixedFormatPattern}
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class FixedFormatPatternData {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatPatternData.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatPatternData.java
@@ -29,10 +29,20 @@ public class FixedFormatPatternData {
   private String pattern;
   public static final FixedFormatPatternData DEFAULT = new FixedFormatPatternData(DATE_PATTERN);
 
+  /**
+   * Creates a pattern data object with the given date/time pattern.
+   *
+   * @param pattern the date/time pattern string (e.g. {@code "yyyyMMdd"})
+   */
   public FixedFormatPatternData(String pattern) {
     this.pattern = pattern;
   }
 
+  /**
+   * Returns the date/time pattern string.
+   *
+   * @return the pattern (e.g. {@code "yyyyMMdd"})
+   */
   public String getPattern() {
     return pattern;
   }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatPatternData.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatPatternData.java
@@ -39,8 +39,6 @@ public class FixedFormatPatternData {
 
 
   public String toString() {
-    return "FixedFormatPatternData{" +
-        "pattern='" + pattern + '\'' +
-        '}';
+    return String.format("FixedFormatPatternData{pattern='%s'}", pattern);
   }
 }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AbstractDecimalFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AbstractDecimalFormatter.java
@@ -34,6 +34,7 @@ public abstract class AbstractDecimalFormatter<T extends Number> extends Abstrac
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractDecimalFormatter.class);
 
+  /** {@inheritDoc} */
   public String asString(T obj, FormatInstructions instructions) {
     BigDecimal roundedValue = null;
     int decimals = instructions.getFixedFormatDecimalData().getDecimals();

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AbstractDecimalFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AbstractDecimalFormatter.java
@@ -27,7 +27,7 @@ import java.text.DecimalFormat;
 /**
  * Base class for formatting decimal data
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public abstract class AbstractDecimalFormatter<T extends Number> extends AbstractNumberFormatter<T> {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AbstractDecimalFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AbstractDecimalFormatter.java
@@ -45,7 +45,7 @@ public abstract class AbstractDecimalFormatter<T extends Number> extends Abstrac
       roundedValue = value.setScale(decimals, roundingMode);
 
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Value before rounding = '" + value + "', value after rounding = '" + roundedValue + "', decimals = " + decimals + ", rounding mode = " + roundingMode);
+        LOG.debug("Value before rounding = '{}', value after rounding = '{}', decimals = {}, rounding mode = {}", value, roundedValue, decimals, roundingMode);
       }
     }
        
@@ -55,11 +55,11 @@ public abstract class AbstractDecimalFormatter<T extends Number> extends Abstrac
 
     char decimalSeparator = formatter.getDecimalFormatSymbols().getDecimalSeparator();
     char groupingSeparator = formatter.getDecimalFormatSymbols().getGroupingSeparator();
-    String zeroString = "0" + decimalSeparator + "0";
+    String zeroString = String.format("0%c0", decimalSeparator);
 
     String rawString = roundedValue != null ? formatter.format(roundedValue) : zeroString;
     if (LOG.isDebugEnabled()) {
-      LOG.debug("rawString: " + rawString + " - G[" + groupingSeparator + "] D[" + decimalSeparator + "]");
+      LOG.debug("rawString: {} - G[{}] D[{}]", rawString, groupingSeparator, decimalSeparator);
     }
     rawString = rawString.replaceAll("\\" + groupingSeparator, "");
     boolean useDecimalDelimiter = instructions.getFixedFormatDecimalData().isUseDecimalDelimiter();
@@ -67,17 +67,17 @@ public abstract class AbstractDecimalFormatter<T extends Number> extends Abstrac
     String beforeDelimiter = rawString.substring(0, rawString.indexOf(decimalSeparator));
     String afterDelimiter = rawString.substring(rawString.indexOf(decimalSeparator)+1, rawString.length());
     if (LOG.isDebugEnabled()) {
-      LOG.debug("beforeDelimiter[" + beforeDelimiter + "], afterDelimiter[" + afterDelimiter + "]");
+      LOG.debug("beforeDelimiter[{}], afterDelimiter[{}]", beforeDelimiter, afterDelimiter);
     }
 
     //trim decimals
     afterDelimiter = StringUtils.substring(afterDelimiter, 0, decimals);
     afterDelimiter = StringUtils.rightPad(afterDelimiter, decimals, '0');
 
-    String delimiter = useDecimalDelimiter ? "" + instructions.getFixedFormatDecimalData().getDecimalDelimiter() : "";
+    String delimiter = useDecimalDelimiter ? String.valueOf(instructions.getFixedFormatDecimalData().getDecimalDelimiter()) : "";
     String result = beforeDelimiter + delimiter + afterDelimiter;
     if (LOG.isDebugEnabled()) {
-      LOG.debug("result[" + result + "]");
+      LOG.debug("result[{}]", result);
     }
     return result;
   }
@@ -107,7 +107,7 @@ public abstract class AbstractDecimalFormatter<T extends Number> extends Abstrac
       toConvert = beforeDelimiter + '.' + afterDelimiter;
     }
     if (applyNegativeSign) {
-      toConvert = "-" + toConvert;
+      toConvert = "-".concat(toConvert);
     }
     return toConvert;
   }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AbstractNumberFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AbstractNumberFormatter.java
@@ -22,7 +22,7 @@ import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
 /**
  * Apply signing to values
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.1.0
  */
 public abstract class AbstractNumberFormatter<T> extends AbstractFixedFormatter<T> {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AnnotationScanner.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AnnotationScanner.java
@@ -1,0 +1,87 @@
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.Fields;
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import static java.lang.String.format;
+
+/**
+ * Discovers all {@link Field} and {@link Fields} annotation targets on a class.
+ *
+ * <p>Pass 1 walks public methods; pass 2 walks declared fields including superclasses.
+ * Field annotations take priority over method annotations for the same property.
+ * A conflict (both annotated) is logged as a warning.
+ *
+ * @author Jacob von Eyben - https://eybenconsult.com
+ * @since 1.5.1
+ */
+class AnnotationScanner {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AnnotationScanner.class);
+
+  /**
+   * Returns all annotation targets for the given class in declaration order.
+   */
+  List<AnnotationTarget> scan(Class<?> clazz) {
+    LinkedHashMap<String, AnnotationTarget> targets = new LinkedHashMap<>();
+
+    // Pass 1: method annotations
+    for (Method method : clazz.getMethods()) {
+      if (method.getAnnotation(Field.class) != null || method.getAnnotation(Fields.class) != null) {
+        targets.put(stripMethodPrefix(method.getName()), AnnotationTarget.ofMethod(method));
+      }
+    }
+
+    // Pass 2: field annotations — walk class hierarchy
+    Class<?> current = clazz;
+    while (current != null && current != Object.class) {
+      for (java.lang.reflect.Field javaField : current.getDeclaredFields()) {
+        if (javaField.getAnnotation(Field.class) == null && javaField.getAnnotation(Fields.class) == null) {
+          continue;
+        }
+        Method getter = findGetter(clazz, javaField);
+        String key = stripMethodPrefix(getter.getName());
+        if (targets.containsKey(key)) {
+          LOG.error("Configuration mismatch: @Field annotation found on both field '{}' and its getter method '{}' in class '{}'. The field annotation will be used.",
+              javaField.getName(), getter.getName(), clazz.getName());
+        }
+        targets.put(key, AnnotationTarget.ofField(getter, javaField));
+      }
+      current = current.getSuperclass();
+    }
+
+    return new ArrayList<>(targets.values());
+  }
+
+  private Method findGetter(Class<?> clazz, java.lang.reflect.Field field) {
+    String name = field.getName();
+    String cap = Character.toUpperCase(name.charAt(0)) + name.substring(1);
+    try {
+      return clazz.getMethod("get" + cap);
+    } catch (NoSuchMethodException e) {
+      try {
+        return clazz.getMethod("is" + cap);
+      } catch (NoSuchMethodException e2) {
+        throw new FixedFormatException(format("No getter found for field '%s' in class %s. Expected 'get%s()' or 'is%s()'.", name, clazz.getName(), cap, cap));
+      }
+    }
+  }
+
+  String stripMethodPrefix(String name) {
+    if (name.startsWith("get") || name.startsWith("set")) {
+      return name.substring(3);
+    } else if (name.startsWith("is")) {
+      return name.substring(2);
+    } else {
+      return name;
+    }
+  }
+}

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AnnotationScanner.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AnnotationScanner.java
@@ -20,7 +20,7 @@ import static java.lang.String.format;
  * Field annotations take priority over method annotations for the same property.
  * A conflict (both annotated) is logged as a warning.
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.5.1
  */
 class AnnotationScanner {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AnnotationTarget.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AnnotationTarget.java
@@ -9,7 +9,7 @@ import java.lang.reflect.Method;
  * {@code @Field} annotation is on the getter, both references point to the same object.
  * When it is on a Java field, they differ.
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.5.1
  */
 class AnnotationTarget {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AnnotationTarget.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AnnotationTarget.java
@@ -1,0 +1,34 @@
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+
+/**
+ * Pairs a getter {@link Method} (used for invocation and type resolution) with an
+ * {@link AnnotatedElement} (used for supplementary annotation lookup). When the
+ * {@code @Field} annotation is on the getter, both references point to the same object.
+ * When it is on a Java field, they differ.
+ *
+ * @author Jacob von Eyben - https://eybenconsult.com
+ * @since 1.5.1
+ */
+class AnnotationTarget {
+
+  final Method getter;
+  final AnnotatedElement annotationSource;
+
+  private AnnotationTarget(Method getter, AnnotatedElement annotationSource) {
+    this.getter = getter;
+    this.annotationSource = annotationSource;
+  }
+
+  /** Annotation is on the getter — getter serves as both invoker and annotation source. */
+  static AnnotationTarget ofMethod(Method method) {
+    return new AnnotationTarget(method, method);
+  }
+
+  /** Annotation is on a Java field — getter is derived, field is the annotation source. */
+  static AnnotationTarget ofField(Method getter, java.lang.reflect.Field field) {
+    return new AnnotationTarget(getter, field);
+  }
+}

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/BigDecimalFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/BigDecimalFormatter.java
@@ -27,6 +27,7 @@ import java.math.BigDecimal;
  */
 public class BigDecimalFormatter extends AbstractDecimalFormatter<BigDecimal> {
 
+    /** {@inheritDoc} */
     public BigDecimal asObject(String string, FormatInstructions instructions) {
       String toConvert = getStringToConvert(string, instructions);
       return new BigDecimal("".equals(toConvert) ? "0" : toConvert);

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/BigDecimalFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/BigDecimalFormatter.java
@@ -22,7 +22,7 @@ import java.math.BigDecimal;
 /**
  * Formatter for {@link BigDecimal} data
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class BigDecimalFormatter extends AbstractDecimalFormatter<BigDecimal> {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/BooleanFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/BooleanFormatter.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class BooleanFormatter extends AbstractFixedFormatter<Boolean> {
 
+  /** {@inheritDoc} */
   public Boolean asObject(String string, FormatInstructions instructions) throws FixedFormatException {
     Boolean result = false;
     if (!StringUtils.isEmpty(string)) {
@@ -42,6 +43,7 @@ public class BooleanFormatter extends AbstractFixedFormatter<Boolean> {
     return result;
   }
 
+  /** {@inheritDoc} */
   public String asString(Boolean obj, FormatInstructions instructions) {
     String result = instructions.getFixedFormatBooleanData().getFalseValue();
     if (obj != null) {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/BooleanFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/BooleanFormatter.java
@@ -23,7 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 /**
  * Formatter for {@link Boolean} data
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class BooleanFormatter extends AbstractFixedFormatter<Boolean> {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/BooleanFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/BooleanFormatter.java
@@ -36,7 +36,7 @@ public class BooleanFormatter extends AbstractFixedFormatter<Boolean> {
       } else if (instructions.getFixedFormatBooleanData().getFalseValue().equals(string)) {
         result = false;
       } else {
-        throw new FixedFormatException("Could not convert string[" + string + "] to boolean value according to booleanData[" + instructions.getFixedFormatBooleanData() + "]");
+        throw new FixedFormatException(String.format("Could not convert string[%s] to boolean value according to booleanData[%s]", string, instructions.getFixedFormatBooleanData()));
       }
     }
     return result;

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ByTypeFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ByTypeFormatter.java
@@ -33,7 +33,7 @@ import java.util.Map;
  * {@link Character}, {@link Boolean}, {@link Double}, {@link Float} and {@link BigDecimal}
  *
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class ByTypeFormatter implements FixedFormatter<Object> {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ByTypeFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ByTypeFormatter.java
@@ -86,12 +86,12 @@ public class ByTypeFormatter implements FixedFormatter<Object> {
       try {
         return formatterClass.getConstructor().newInstance();
       } catch (NoSuchMethodException e) {
-        throw new FixedFormatException("Could not create instance of[" + formatterClass.getName() + "] because no default constructor exists");
+        throw new FixedFormatException(String.format("Could not create instance of[%s] because no default constructor exists", formatterClass.getName()));
       } catch (Exception e) {
-        throw new FixedFormatException("Could not create instance of[" + formatterClass.getName() + "]", e);
+        throw new FixedFormatException(String.format("Could not create instance of[%s]", formatterClass.getName()), e);
       }
     } else {
-      throw new FixedFormatException(ByTypeFormatter.class.getName() + " cannot handle datatype[" + dataType.getName() + "]. Provide your own custom FixedFormatter for this datatype.");
+      throw new FixedFormatException(String.format("%s cannot handle datatype[%s]. Provide your own custom FixedFormatter for this datatype.", ByTypeFormatter.class.getName(), dataType.getName()));
     }
   }
 }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ByTypeFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ByTypeFormatter.java
@@ -62,23 +62,38 @@ public class ByTypeFormatter implements FixedFormatter<Object> {
     KNOWN_FORMATTERS.put(BigDecimal.class,  BigDecimalFormatter.class);
   }
 
+  /**
+   * Creates a {@code ByTypeFormatter} bound to the given format context.
+   * The context's data type is used at runtime to select the appropriate typed formatter.
+   *
+   * @param context the format context describing the field's offset, data type, and formatter class
+   */
   public ByTypeFormatter(FormatContext<?> context) {
     this.context = context;
   }
 
-
+  /** {@inheritDoc} */
   @SuppressWarnings("unchecked")
   public Object parse(String value, FormatInstructions instructions) {
     FixedFormatter<Object> formatter = (FixedFormatter<Object>) actualFormatter(context.getDataType());
     return formatter.parse(value, instructions);
   }
 
+  /** {@inheritDoc} */
   @SuppressWarnings("unchecked")
   public String format(Object value, FormatInstructions instructions) {
     FixedFormatter<Object> formatter = (FixedFormatter<Object>) actualFormatter(context.getDataType());
     return formatter.format(value, instructions);
   }
 
+  /**
+   * Looks up and instantiates the typed formatter for the given {@code dataType}.
+   *
+   * @param dataType the Java type of the field value
+   * @return a formatter capable of handling {@code dataType}
+   * @throws com.ancientprogramming.fixedformat4j.exception.FixedFormatException if no formatter is
+   *         registered for {@code dataType} or the formatter cannot be instantiated
+   */
   public FixedFormatter<?> actualFormatter(final Class<?> dataType) {
     Class<? extends FixedFormatter<?>> formatterClass = KNOWN_FORMATTERS.get(dataType);
 

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/CharacterFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/CharacterFormatter.java
@@ -31,6 +31,7 @@ public class CharacterFormatter extends AbstractFixedFormatter<Character> {
 
   private static final Logger LOG = LoggerFactory.getLogger(CharacterFormatter.class);
 
+  /** {@inheritDoc} */
   public Character asObject(String string, FormatInstructions instructions) {
     Character result = null;
     if (!StringUtils.isEmpty(string)) {
@@ -42,6 +43,7 @@ public class CharacterFormatter extends AbstractFixedFormatter<Character> {
     return result;
   }
 
+  /** {@inheritDoc} */
   public String asString(Character obj, FormatInstructions instructions) {
     String result = "";
     if (obj != null) {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/CharacterFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/CharacterFormatter.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 /**
  * Formatter for {@link Character} data
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class CharacterFormatter extends AbstractFixedFormatter<Character> {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/CharacterFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/CharacterFormatter.java
@@ -36,7 +36,7 @@ public class CharacterFormatter extends AbstractFixedFormatter<Character> {
     if (!StringUtils.isEmpty(string)) {
       result = string.charAt(0);
       if (string.length() > 1) {
-        LOG.warn("found more than one character[" + string + "] after reading instructions from record. Will return first character[" + result + "]");
+        LOG.warn("found more than one character[{}] after reading instructions from record. Will return first character[{}]", string, result);
       }
     }
     return result;

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/DateFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/DateFormatter.java
@@ -34,6 +34,7 @@ import java.util.Date;
  */
 public class DateFormatter extends AbstractFixedFormatter<Date> {
 
+  /** {@inheritDoc} */
   public Date asObject(String string, FormatInstructions instructions) throws FixedFormatException {
     Date result = null;
 
@@ -47,6 +48,7 @@ public class DateFormatter extends AbstractFixedFormatter<Date> {
     return result;
   }
 
+  /** {@inheritDoc} */
   public String asString(Date date, FormatInstructions instructions) {
     String result = null;
     if (date != null) {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/DateFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/DateFormatter.java
@@ -29,7 +29,7 @@ import java.util.Date;
  * Formatter for {@link java.util.Date} data.
  * The formatting and parsing is perfomed by using an instance of the {@link SimpleDateFormat} class.
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class DateFormatter extends AbstractFixedFormatter<Date> {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/DateFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/DateFormatter.java
@@ -41,7 +41,7 @@ public class DateFormatter extends AbstractFixedFormatter<Date> {
       try {
         result = getFormatter(instructions.getFixedFormatPatternData().getPattern()).parse(string);
       } catch (ParseException e) {
-        throw new FixedFormatException("Could not parse value[" + string + "] by pattern[" + instructions.getFixedFormatPatternData().getPattern() + "] to " + Date.class.getName());
+        throw new FixedFormatException(String.format("Could not parse value[%s] by pattern[%s] to %s", string, instructions.getFixedFormatPatternData().getPattern(), Date.class.getName()));
       }
     }
     return result;

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/DoubleFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/DoubleFormatter.java
@@ -25,6 +25,7 @@ import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
  */
 public class DoubleFormatter extends AbstractDecimalFormatter<Double> {
 
+  /** {@inheritDoc} */
   public Double asObject(String string, FormatInstructions instructions) {
     String toConvert = getStringToConvert(string, instructions);
     return Double.parseDouble("".equals(toConvert) ? "0" : toConvert);

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/DoubleFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/DoubleFormatter.java
@@ -20,7 +20,7 @@ import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
 /**
  * Formatter for {@link Double} data
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class DoubleFormatter extends AbstractDecimalFormatter<Double> {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
@@ -38,14 +38,22 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.math.RoundingMode;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import static com.ancientprogramming.fixedformat4j.format.FixedFormatUtil.fetchData;
 import static com.ancientprogramming.fixedformat4j.format.FixedFormatUtil.getFixedFormatterInstance;
@@ -189,7 +197,11 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
       Field fieldAnnotation = target.annotationSource.getAnnotation(Field.class);
       Fields fieldsAnnotation = target.annotationSource.getAnnotation(Fields.class);
       if (fieldAnnotation != null) {
-        foundData.put(fieldAnnotation.offset(), exportDataAccordingFieldAnnotation(fixedFormatRecord, target, fieldAnnotation));
+        if (fieldAnnotation.count() > 1) {
+          exportRepeatingFieldData(fixedFormatRecord, target, fieldAnnotation, foundData);
+        } else {
+          foundData.put(fieldAnnotation.offset(), exportDataAccordingFieldAnnotation(fixedFormatRecord, target, fieldAnnotation));
+        }
       } else if (fieldsAnnotation != null) {
         for (Field field : fieldsAnnotation.value()) {
           foundData.put(field.offset(), exportDataAccordingFieldAnnotation(fixedFormatRecord, target, field));
@@ -238,6 +250,12 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
 
   @SuppressWarnings({"unchecked"})
   protected <T> Object readDataAccordingFieldAnnotation(Class<T> clazz, String data, Method getter, AnnotatedElement annotationSource, Field fieldAnno) throws ParseException {
+    validateCountAnnotation(getter, fieldAnno);
+
+    if (fieldAnno.count() > 1) {
+      return readRepeatingFieldData(clazz, data, getter, annotationSource, fieldAnno);
+    }
+
     Class<?> datatype = getDatatype(getter, fieldAnno);
 
     FormatContext<?> context = getFormatContext(datatype, fieldAnno);
@@ -264,6 +282,154 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
     return loadedData;
   }
 
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private <T> Object readRepeatingFieldData(Class<T> clazz, String data, Method getter, AnnotatedElement annotationSource, Field fieldAnno) {
+    int count = fieldAnno.count();
+    Class<?> elementType = resolveElementType(getter);
+    FormatInstructions formatdata = getFormatInstructions(annotationSource, fieldAnno);
+
+    FormatContext protoContext = new FormatContext(fieldAnno.offset(), elementType, fieldAnno.formatter());
+    FixedFormatter<Object> formatter = (FixedFormatter<Object>) getFixedFormatterInstance(protoContext.getFormatter(), protoContext);
+
+    List<Object> elements = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      int elementOffset = fieldAnno.offset() + fieldAnno.length() * i;
+      FormatContext elementContext = new FormatContext(elementOffset, elementType, fieldAnno.formatter());
+      String dataToParse = fetchData(data, formatdata, elementContext);
+      try {
+        elements.add(formatter.parse(dataToParse, formatdata));
+      } catch (RuntimeException e) {
+        throw new ParseException(data, dataToParse, clazz, getter, elementContext, formatdata, e);
+      }
+    }
+
+    return assembleCollection(getter, elements);
+  }
+
+  @SuppressWarnings({"unchecked"})
+  private <T> void exportRepeatingFieldData(T fixedFormatRecord, AnnotationTarget target, Field fieldAnno, HashMap<Integer, String> foundData) {
+    validateCountAnnotation(target.getter, fieldAnno);
+
+    Object value;
+    try {
+      value = target.getter.invoke(fixedFormatRecord);
+    } catch (Exception e) {
+      throw new FixedFormatException(format("could not invoke %s", fieldLabel(target.getter)), e);
+    }
+
+    if (value == null) {
+      throw new FixedFormatException("Cannot export null repeating field on " + fieldLabel(target.getter));
+    }
+
+    int count = fieldAnno.count();
+    int actualSize = value.getClass().isArray() ? Array.getLength(value) : ((Collection<?>) value).size();
+
+    if (actualSize != count) {
+      if (fieldAnno.strictExportCount()) {
+        throw new FixedFormatException(
+            "Repeating field " + fieldLabel(target.getter) + " has count=" + count
+            + " but collection size=" + actualSize);
+      } else {
+        LOG.warn("Repeating field {} has count={} but collection size={}. Exporting {} elements.",
+            fieldLabel(target.getter), count, actualSize, Math.min(count, actualSize));
+      }
+    }
+
+    int exportCount = Math.min(count, actualSize);
+    Class<?> elementType = resolveElementType(target.getter);
+    FormatInstructions formatdata = getFormatInstructions(target.annotationSource, fieldAnno);
+    @SuppressWarnings("rawtypes")
+    FormatContext protoContext = new FormatContext(fieldAnno.offset(), elementType, fieldAnno.formatter());
+    FixedFormatter<Object> formatter = (FixedFormatter<Object>) getFixedFormatterInstance(protoContext.getFormatter(), protoContext);
+
+    Iterable<?> iterable = value.getClass().isArray() ? arrayToIterable(value, exportCount) : (Collection<?>) value;
+
+    int i = 0;
+    for (Object element : iterable) {
+      if (i >= exportCount) break;
+      int elementOffset = fieldAnno.offset() + fieldAnno.length() * i;
+      foundData.put(elementOffset, formatter.format(element, formatdata));
+      i++;
+    }
+  }
+
+  private Iterable<Object> arrayToIterable(Object array, int limit) {
+    List<Object> list = new ArrayList<>(limit);
+    for (int i = 0; i < limit; i++) {
+      list.add(Array.get(array, i));
+    }
+    return list;
+  }
+
+  private void validateCountAnnotation(Method method, Field fieldAnnotation) {
+    int count = fieldAnnotation.count();
+    Class<?> returnType = method.getReturnType();
+    boolean isArrayOrCollection = returnType.isArray()
+        || Collection.class.isAssignableFrom(returnType)
+        || Iterable.class.isAssignableFrom(returnType);
+
+    if (count < 1) {
+      throw new FixedFormatException(
+          "@Field count must be >= 1 on " + fieldLabel(method) + ", was: " + count);
+    }
+    if (count == 1 && isArrayOrCollection) {
+      throw new FixedFormatException(
+          "@Field count=1 but return type is array/collection on " + fieldLabel(method)
+          + ". Use count > 1 for repeating fields.");
+    }
+    if (count > 1 && !isArrayOrCollection) {
+      throw new FixedFormatException(
+          "@Field count=" + count + " requires array or Collection return type on "
+          + fieldLabel(method) + ", found: " + returnType.getName());
+    }
+  }
+
+  private Class<?> resolveElementType(Method method) {
+    Class<?> returnType = method.getReturnType();
+    if (returnType.isArray()) {
+      return returnType.getComponentType();
+    }
+    Type genericReturnType = method.getGenericReturnType();
+    if (genericReturnType instanceof ParameterizedType) {
+      ParameterizedType pt = (ParameterizedType) genericReturnType;
+      Type[] typeArgs = pt.getActualTypeArguments();
+      if (typeArgs.length > 0 && typeArgs[0] instanceof Class) {
+        return (Class<?>) typeArgs[0];
+      }
+    }
+    throw new FixedFormatException("Cannot determine element type for repeating field on " + fieldLabel(method)
+        + ". Ensure the collection is parameterized (e.g. List<String>, not List).");
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private Object assembleCollection(Method getter, List<Object> elements) {
+    Class<?> returnType = getter.getReturnType();
+    if (returnType.isArray()) {
+      Object array = Array.newInstance(returnType.getComponentType(), elements.size());
+      for (int i = 0; i < elements.size(); i++) {
+        Array.set(array, i, elements.get(i));
+      }
+      return array;
+    } else if (LinkedList.class.isAssignableFrom(returnType)) {
+      return new LinkedList<>(elements);
+    } else if (List.class.isAssignableFrom(returnType)) {
+      return new ArrayList<>(elements);
+    } else if (SortedSet.class.isAssignableFrom(returnType)) {
+      return new TreeSet<>(elements);
+    } else if (Set.class.isAssignableFrom(returnType)) {
+      return new LinkedHashSet<>(elements);
+    } else if (Collection.class.isAssignableFrom(returnType) || Iterable.class.isAssignableFrom(returnType)) {
+      return new ArrayList<>(elements);
+    } else {
+      throw new FixedFormatException("Unsupported collection type " + returnType.getName()
+          + " on " + fieldLabel(getter) + ". Supported types: arrays, List, LinkedList, Set, SortedSet, Collection.");
+    }
+  }
+
+  private static String fieldLabel(Method method) {
+    return method.getDeclaringClass().getName() + "#" + method.getName() + "()";
+  }
+
   private Class<?> getDatatype(Method method, Field fieldAnno) {
     if (followsBeanStandard(method)) {
       return method.getReturnType();
@@ -273,6 +439,8 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
 
   @SuppressWarnings({"unchecked"})
   private <T> String exportDataAccordingFieldAnnotation(T fixedFormatRecord, AnnotationTarget target, Field fieldAnno) {
+    validateCountAnnotation(target.getter, fieldAnno);
+
     Class<?> datatype = getDatatype(target.getter, fieldAnno);
 
     FormatContext<?> context = getFormatContext(datatype, fieldAnno);

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
@@ -41,7 +41,7 @@ import static java.lang.String.format;
 /**
  * Load and export objects to and from fixed formatted string representation
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class FixedFormatManagerImpl implements FixedFormatManager {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
@@ -197,7 +197,7 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
       }
     }
     if (LOG.isDebugEnabled()) {
-      LOG.debug("the loaded data[" + loadedData + "]");
+      LOG.debug("the loaded data[{}]", loadedData);
     }
     return loadedData;
   }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
@@ -17,10 +17,6 @@ package com.ancientprogramming.fixedformat4j.format.impl;
 
 import com.ancientprogramming.fixedformat4j.annotation.Field;
 import com.ancientprogramming.fixedformat4j.annotation.Fields;
-import com.ancientprogramming.fixedformat4j.annotation.FixedFormatBoolean;
-import com.ancientprogramming.fixedformat4j.annotation.FixedFormatDecimal;
-import com.ancientprogramming.fixedformat4j.annotation.FixedFormatNumber;
-import com.ancientprogramming.fixedformat4j.annotation.FixedFormatPattern;
 import com.ancientprogramming.fixedformat4j.annotation.Record;
 import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
 import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
@@ -28,32 +24,15 @@ import com.ancientprogramming.fixedformat4j.format.FixedFormatter;
 import com.ancientprogramming.fixedformat4j.format.FormatContext;
 import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
 import com.ancientprogramming.fixedformat4j.format.ParseException;
-import com.ancientprogramming.fixedformat4j.format.data.FixedFormatBooleanData;
-import com.ancientprogramming.fixedformat4j.format.data.FixedFormatDecimalData;
-import com.ancientprogramming.fixedformat4j.format.data.FixedFormatNumberData;
-import com.ancientprogramming.fixedformat4j.format.data.FixedFormatPatternData;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Array;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.math.RoundingMode;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
 
 import static com.ancientprogramming.fixedformat4j.format.FixedFormatUtil.fetchData;
 import static com.ancientprogramming.fixedformat4j.format.FixedFormatUtil.getFixedFormatterInstance;
@@ -69,69 +48,10 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(FixedFormatManagerImpl.class);
 
-  /**
-   * Pairs a getter {@link Method} (used for invocation and type resolution) with an
-   * {@link AnnotatedElement} (used for supplementary annotation lookup). When the
-   * {@link Field} annotation is on the getter, both references point to the same object.
-   * When it is on a Java field, they differ.
-   */
-  private static final class AnnotationTarget {
-    final Method getter;
-    final AnnotatedElement annotationSource;
-
-    private AnnotationTarget(Method getter, AnnotatedElement annotationSource) {
-      this.getter = getter;
-      this.annotationSource = annotationSource;
-    }
-
-    /** Annotation is on the getter — getter serves as both invoker and annotation source. */
-    static AnnotationTarget ofMethod(Method method) {
-      return new AnnotationTarget(method, method);
-    }
-
-    /** Annotation is on a Java field — getter is derived, field is the annotation source. */
-    static AnnotationTarget ofField(Method getter, java.lang.reflect.Field field) {
-      return new AnnotationTarget(getter, field);
-    }
-  }
-
-  /**
-   * Collects all {@link AnnotationTarget}s for the given class.
-   *
-   * Pass 1 walks public methods; pass 2 walks declared fields (including superclasses).
-   * Field annotations take priority over method annotations for the same property.
-   * A conflict (both annotated) is logged as an error.
-   */
-  private List<AnnotationTarget> collectAnnotationTargets(Class<?> clazz) {
-    LinkedHashMap<String, AnnotationTarget> targets = new LinkedHashMap<>();
-
-    // Pass 1: method annotations
-    for (Method method : clazz.getMethods()) {
-      if (method.getAnnotation(Field.class) != null || method.getAnnotation(Fields.class) != null) {
-        targets.put(stripMethodPrefix(method.getName()), AnnotationTarget.ofMethod(method));
-      }
-    }
-
-    // Pass 2: field annotations — walk class hierarchy
-    Class<?> current = clazz;
-    while (current != null && current != Object.class) {
-      for (java.lang.reflect.Field javaField : current.getDeclaredFields()) {
-        if (javaField.getAnnotation(Field.class) == null && javaField.getAnnotation(Fields.class) == null) {
-          continue;
-        }
-        Method getter = findGetter(clazz, javaField);
-        String key = stripMethodPrefix(getter.getName());
-        if (targets.containsKey(key)) {
-          LOG.error("Configuration mismatch: @Field annotation found on both field '{}' and its getter method '{}' in class '{}'. The field annotation will be used.",
-              javaField.getName(), getter.getName(), clazz.getName());
-        }
-        targets.put(key, AnnotationTarget.ofField(getter, javaField));
-      }
-      current = current.getSuperclass();
-    }
-
-    return new ArrayList<>(targets.values());
-  }
+  private final AnnotationScanner annotationScanner = new AnnotationScanner();
+  private final FormatInstructionsBuilder instructionsBuilder = new FormatInstructionsBuilder();
+  private final RecordInstantiator recordInstantiator = new RecordInstantiator();
+  private final RepeatingFieldSupport repeatingFieldSupport = new RepeatingFieldSupport();
 
   /**
    * {@inheritDoc}
@@ -141,10 +61,10 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
     HashMap<String, Class<?>> methodClass = new HashMap<String, Class<?>>();
     getAndAssertRecordAnnotation(fixedFormatRecordClass);
 
-    T instance = createRecordInstance(fixedFormatRecordClass);
+    T instance = recordInstantiator.instantiate(fixedFormatRecordClass);
 
-    for (AnnotationTarget target : collectAnnotationTargets(fixedFormatRecordClass)) {
-      String methodName = stripMethodPrefix(target.getter.getName());
+    for (AnnotationTarget target : annotationScanner.scan(fixedFormatRecordClass)) {
+      String methodName = annotationScanner.stripMethodPrefix(target.getter.getName());
       Field fieldAnnotation = target.annotationSource.getAnnotation(Field.class);
       Fields fieldsAnnotation = target.annotationSource.getAnnotation(Fields.class);
       if (fieldAnnotation != null) {
@@ -193,12 +113,12 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
     Record record = getAndAssertRecordAnnotation(fixedFormatRecord.getClass());
 
     HashMap<Integer, String> foundData = new HashMap<Integer, String>();
-    for (AnnotationTarget target : collectAnnotationTargets(fixedFormatRecord.getClass())) {
+    for (AnnotationTarget target : annotationScanner.scan(fixedFormatRecord.getClass())) {
       Field fieldAnnotation = target.annotationSource.getAnnotation(Field.class);
       Fields fieldsAnnotation = target.annotationSource.getAnnotation(Fields.class);
       if (fieldAnnotation != null) {
         if (fieldAnnotation.count() > 1) {
-          exportRepeatingFieldData(fixedFormatRecord, target, fieldAnnotation, foundData);
+          repeatingFieldSupport.export(fixedFormatRecord, target, fieldAnnotation, foundData);
         } else {
           foundData.put(fieldAnnotation.offset(), exportDataAccordingFieldAnnotation(fixedFormatRecord, target, fieldAnnotation));
         }
@@ -250,17 +170,17 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
 
   @SuppressWarnings({"unchecked"})
   protected <T> Object readDataAccordingFieldAnnotation(Class<T> clazz, String data, Method getter, AnnotatedElement annotationSource, Field fieldAnno) throws ParseException {
-    validateCountAnnotation(getter, fieldAnno);
+    repeatingFieldSupport.validateCount(getter, fieldAnno);
 
     if (fieldAnno.count() > 1) {
-      return readRepeatingFieldData(clazz, data, getter, annotationSource, fieldAnno);
+      return repeatingFieldSupport.read(clazz, data, getter, annotationSource, fieldAnno);
     }
 
-    Class<?> datatype = getDatatype(getter, fieldAnno);
+    Class<?> datatype = instructionsBuilder.datatype(getter, fieldAnno);
 
-    FormatContext<?> context = getFormatContext(datatype, fieldAnno);
+    FormatContext<?> context = instructionsBuilder.context(datatype, fieldAnno);
     FixedFormatter<?> formatter = getFixedFormatterInstance(context.getFormatter(), context);
-    FormatInstructions formatdata = getFormatInstructions(annotationSource, fieldAnno);
+    FormatInstructions formatdata = instructionsBuilder.build(annotationSource, fieldAnno);
 
     String dataToParse = fetchData(data, formatdata, context);
 
@@ -282,170 +202,15 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
     return loadedData;
   }
 
-  @SuppressWarnings({"unchecked", "rawtypes"})
-  private <T> Object readRepeatingFieldData(Class<T> clazz, String data, Method getter, AnnotatedElement annotationSource, Field fieldAnno) {
-    int count = fieldAnno.count();
-    Class<?> elementType = resolveElementType(getter);
-    FormatInstructions formatdata = getFormatInstructions(annotationSource, fieldAnno);
-
-    FormatContext protoContext = new FormatContext(fieldAnno.offset(), elementType, fieldAnno.formatter());
-    FixedFormatter<Object> formatter = (FixedFormatter<Object>) getFixedFormatterInstance(protoContext.getFormatter(), protoContext);
-
-    List<Object> elements = new ArrayList<>();
-    for (int i = 0; i < count; i++) {
-      int elementOffset = fieldAnno.offset() + fieldAnno.length() * i;
-      FormatContext elementContext = new FormatContext(elementOffset, elementType, fieldAnno.formatter());
-      String dataToParse = fetchData(data, formatdata, elementContext);
-      try {
-        elements.add(formatter.parse(dataToParse, formatdata));
-      } catch (RuntimeException e) {
-        throw new ParseException(data, dataToParse, clazz, getter, elementContext, formatdata, e);
-      }
-    }
-
-    return assembleCollection(getter, elements);
-  }
-
-  @SuppressWarnings({"unchecked"})
-  private <T> void exportRepeatingFieldData(T fixedFormatRecord, AnnotationTarget target, Field fieldAnno, HashMap<Integer, String> foundData) {
-    validateCountAnnotation(target.getter, fieldAnno);
-
-    Object value;
-    try {
-      value = target.getter.invoke(fixedFormatRecord);
-    } catch (Exception e) {
-      throw new FixedFormatException(format("could not invoke %s", fieldLabel(target.getter)), e);
-    }
-
-    if (value == null) {
-      throw new FixedFormatException("Cannot export null repeating field on " + fieldLabel(target.getter));
-    }
-
-    int count = fieldAnno.count();
-    int actualSize = value.getClass().isArray() ? Array.getLength(value) : ((Collection<?>) value).size();
-
-    if (actualSize != count) {
-      if (fieldAnno.strictExportCount()) {
-        throw new FixedFormatException(
-            "Repeating field " + fieldLabel(target.getter) + " has count=" + count
-            + " but collection size=" + actualSize);
-      } else {
-        LOG.warn("Repeating field {} has count={} but collection size={}. Exporting {} elements.",
-            fieldLabel(target.getter), count, actualSize, Math.min(count, actualSize));
-      }
-    }
-
-    int exportCount = Math.min(count, actualSize);
-    Class<?> elementType = resolveElementType(target.getter);
-    FormatInstructions formatdata = getFormatInstructions(target.annotationSource, fieldAnno);
-    @SuppressWarnings("rawtypes")
-    FormatContext protoContext = new FormatContext(fieldAnno.offset(), elementType, fieldAnno.formatter());
-    FixedFormatter<Object> formatter = (FixedFormatter<Object>) getFixedFormatterInstance(protoContext.getFormatter(), protoContext);
-
-    Iterable<?> iterable = value.getClass().isArray() ? arrayToIterable(value, exportCount) : (Collection<?>) value;
-
-    int i = 0;
-    for (Object element : iterable) {
-      if (i >= exportCount) break;
-      int elementOffset = fieldAnno.offset() + fieldAnno.length() * i;
-      foundData.put(elementOffset, formatter.format(element, formatdata));
-      i++;
-    }
-  }
-
-  private Iterable<Object> arrayToIterable(Object array, int limit) {
-    List<Object> list = new ArrayList<>(limit);
-    for (int i = 0; i < limit; i++) {
-      list.add(Array.get(array, i));
-    }
-    return list;
-  }
-
-  private void validateCountAnnotation(Method method, Field fieldAnnotation) {
-    int count = fieldAnnotation.count();
-    Class<?> returnType = method.getReturnType();
-    boolean isArrayOrCollection = returnType.isArray()
-        || Collection.class.isAssignableFrom(returnType)
-        || Iterable.class.isAssignableFrom(returnType);
-
-    if (count < 1) {
-      throw new FixedFormatException(
-          "@Field count must be >= 1 on " + fieldLabel(method) + ", was: " + count);
-    }
-    if (count == 1 && isArrayOrCollection) {
-      throw new FixedFormatException(
-          "@Field count=1 but return type is array/collection on " + fieldLabel(method)
-          + ". Use count > 1 for repeating fields.");
-    }
-    if (count > 1 && !isArrayOrCollection) {
-      throw new FixedFormatException(
-          "@Field count=" + count + " requires array or Collection return type on "
-          + fieldLabel(method) + ", found: " + returnType.getName());
-    }
-  }
-
-  private Class<?> resolveElementType(Method method) {
-    Class<?> returnType = method.getReturnType();
-    if (returnType.isArray()) {
-      return returnType.getComponentType();
-    }
-    Type genericReturnType = method.getGenericReturnType();
-    if (genericReturnType instanceof ParameterizedType) {
-      ParameterizedType pt = (ParameterizedType) genericReturnType;
-      Type[] typeArgs = pt.getActualTypeArguments();
-      if (typeArgs.length > 0 && typeArgs[0] instanceof Class) {
-        return (Class<?>) typeArgs[0];
-      }
-    }
-    throw new FixedFormatException("Cannot determine element type for repeating field on " + fieldLabel(method)
-        + ". Ensure the collection is parameterized (e.g. List<String>, not List).");
-  }
-
-  @SuppressWarnings({"unchecked", "rawtypes"})
-  private Object assembleCollection(Method getter, List<Object> elements) {
-    Class<?> returnType = getter.getReturnType();
-    if (returnType.isArray()) {
-      Object array = Array.newInstance(returnType.getComponentType(), elements.size());
-      for (int i = 0; i < elements.size(); i++) {
-        Array.set(array, i, elements.get(i));
-      }
-      return array;
-    } else if (LinkedList.class.isAssignableFrom(returnType)) {
-      return new LinkedList<>(elements);
-    } else if (List.class.isAssignableFrom(returnType)) {
-      return new ArrayList<>(elements);
-    } else if (SortedSet.class.isAssignableFrom(returnType)) {
-      return new TreeSet<>(elements);
-    } else if (Set.class.isAssignableFrom(returnType)) {
-      return new LinkedHashSet<>(elements);
-    } else if (Collection.class.isAssignableFrom(returnType) || Iterable.class.isAssignableFrom(returnType)) {
-      return new ArrayList<>(elements);
-    } else {
-      throw new FixedFormatException("Unsupported collection type " + returnType.getName()
-          + " on " + fieldLabel(getter) + ". Supported types: arrays, List, LinkedList, Set, SortedSet, Collection.");
-    }
-  }
-
-  private static String fieldLabel(Method method) {
-    return method.getDeclaringClass().getName() + "#" + method.getName() + "()";
-  }
-
-  private Class<?> getDatatype(Method method, Field fieldAnno) {
-    if (followsBeanStandard(method)) {
-      return method.getReturnType();
-    }
-    throw new FixedFormatException(format("Cannot annotate method %s, with %s annotation. %s annotations must be placed on methods starting with 'get' or 'is'", method.getName(), fieldAnno.getClass().getName(), fieldAnno.getClass().getName()));
-  }
-
   @SuppressWarnings({"unchecked"})
   private <T> String exportDataAccordingFieldAnnotation(T fixedFormatRecord, AnnotationTarget target, Field fieldAnno) {
-    validateCountAnnotation(target.getter, fieldAnno);
+    repeatingFieldSupport.validateCount(target.getter, fieldAnno);
 
-    Class<?> datatype = getDatatype(target.getter, fieldAnno);
+    Class<?> datatype = instructionsBuilder.datatype(target.getter, fieldAnno);
 
-    FormatContext<?> context = getFormatContext(datatype, fieldAnno);
+    FormatContext<?> context = instructionsBuilder.context(datatype, fieldAnno);
     FixedFormatter<?> formatter = getFixedFormatterInstance(context.getFormatter(), context);
-    FormatInstructions formatdata = getFormatInstructions(target.annotationSource, fieldAnno);
+    FormatInstructions formatdata = instructionsBuilder.build(target.annotationSource, fieldAnno);
     Object valueObject;
     try {
       valueObject = target.getter.invoke(fixedFormatRecord);
@@ -463,114 +228,5 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
       LOG.debug(format("exported %s ", result));
     }
     return result;
-  }
-
-  private Method findGetter(Class<?> clazz, java.lang.reflect.Field field) {
-    String name = field.getName();
-    String cap = Character.toUpperCase(name.charAt(0)) + name.substring(1);
-    try {
-      return clazz.getMethod("get" + cap);
-    } catch (NoSuchMethodException e) {
-      try {
-        return clazz.getMethod("is" + cap);
-      } catch (NoSuchMethodException e2) {
-        throw new FixedFormatException(format("No getter found for field '%s' in class %s. Expected 'get%s()' or 'is%s()'.", name, clazz.getName(), cap, cap));
-      }
-    }
-  }
-
-  private String stripMethodPrefix(String name) {
-    if (name.startsWith("get") || name.startsWith("set")) {
-      return name.substring(3);
-    } else if (name.startsWith("is")) {
-      return name.substring(2);
-    } else {
-      return name;
-    }
-  }
-
-  @SuppressWarnings({"unchecked", "rawtypes"})
-  private FormatContext<?> getFormatContext(Class<?> datatype, Field fieldAnno) {
-    if (fieldAnno != null) {
-      return new FormatContext(fieldAnno.offset(), datatype, fieldAnno.formatter());
-    }
-    return null;
-  }
-
-  private FormatInstructions getFormatInstructions(AnnotatedElement annotationSource, Field fieldAnno) {
-    FixedFormatPatternData patternData = getFixedFormatPatternData(annotationSource.getAnnotation(FixedFormatPattern.class));
-    FixedFormatBooleanData booleanData = getFixedFormatBooleanData(annotationSource.getAnnotation(FixedFormatBoolean.class));
-    FixedFormatNumberData numberData = getFixedFormatNumberData(annotationSource.getAnnotation(FixedFormatNumber.class));
-    FixedFormatDecimalData decimalData = getFixedFormatDecimalData(annotationSource.getAnnotation(FixedFormatDecimal.class));
-    return new FormatInstructions(fieldAnno.length(), fieldAnno.align(), fieldAnno.paddingChar(), patternData, booleanData, numberData, decimalData);
-  }
-
-  private FixedFormatPatternData getFixedFormatPatternData(FixedFormatPattern annotation) {
-    if (annotation != null) {
-      return new FixedFormatPatternData(annotation.value());
-    }
-    return FixedFormatPatternData.DEFAULT;
-  }
-
-  private FixedFormatBooleanData getFixedFormatBooleanData(FixedFormatBoolean annotation) {
-    if (annotation != null) {
-      return new FixedFormatBooleanData(annotation.trueValue(), annotation.falseValue());
-    }
-    return FixedFormatBooleanData.DEFAULT;
-  }
-
-  private FixedFormatNumberData getFixedFormatNumberData(FixedFormatNumber annotation) {
-    if (annotation != null) {
-      return new FixedFormatNumberData(annotation.sign(), annotation.positiveSign(), annotation.negativeSign());
-    }
-    return FixedFormatNumberData.DEFAULT;
-  }
-
-  private FixedFormatDecimalData getFixedFormatDecimalData(FixedFormatDecimal annotation) {
-    if (annotation != null) {
-      return new FixedFormatDecimalData(annotation.decimals(), annotation.useDecimalDelimiter(), annotation.decimalDelimiter(), RoundingMode.valueOf(annotation.roundingMode()));
-    }
-    return FixedFormatDecimalData.DEFAULT;
-  }
-
-  private boolean followsBeanStandard(Method method) {
-    String methodName = method.getName();
-    return methodName.startsWith("get") || methodName.startsWith("is");
-  }
-
-  private <T> T createRecordInstance(Class<T> fixedFormatRecordClass) {
-    T instance;
-    try {
-      Constructor<T> constructor = fixedFormatRecordClass.getDeclaredConstructor();
-      instance = constructor.newInstance();
-    } catch (NoSuchMethodException e) {
-      Class<?> declaringClass = fixedFormatRecordClass.getDeclaringClass();
-      if (declaringClass != null) {
-        try {
-          Object declaringClassInstance;
-          try {
-            Constructor<?> declaringClassConstructor = declaringClass.getDeclaredConstructor();
-            declaringClassInstance = declaringClassConstructor.newInstance();
-          } catch (NoSuchMethodException dex) {
-            throw new FixedFormatException(format("Trying to create instance of innerclass %s, but the declaring class %s is missing a default constructor which is nessesary to be loaded through %s", fixedFormatRecordClass.getName(), declaringClass.getName(), getClass().getName()));
-          } catch (Exception de) {
-            throw new FixedFormatException(format("unable to create instance of declaring class %s, which is needed to instansiate %s", declaringClass.getName(), fixedFormatRecordClass.getName()), e);
-          }
-          Constructor<T> constructor = fixedFormatRecordClass.getDeclaredConstructor(declaringClass);
-          instance = constructor.newInstance(declaringClassInstance);
-        } catch (FixedFormatException ex) {
-          throw ex;
-        } catch (NoSuchMethodException ex) {
-          throw new FixedFormatException(format("%s is missing a default constructor which is nessesary to be loaded through %s", fixedFormatRecordClass.getName(), getClass().getName()));
-        } catch (Exception ex) {
-          throw new FixedFormatException(format("unable to create instance of %s", fixedFormatRecordClass.getName()), e);
-        }
-      } else {
-        throw new FixedFormatException(format("%s is missing a default constructor which is nessesary to be loaded through %s", fixedFormatRecordClass.getName(), getClass().getName()));
-      }
-    } catch (Exception e) {
-      throw new FixedFormatException(format("unable to create instance of %s", fixedFormatRecordClass.getName()), e);
-    }
-    return instance;
   }
 }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FloatFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FloatFormatter.java
@@ -25,6 +25,7 @@ import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
  */
 public class FloatFormatter extends AbstractDecimalFormatter<Float> {
   
+  /** {@inheritDoc} */
   public Float asObject(String string, FormatInstructions instructions) {
       String toConvert = getStringToConvert(string, instructions);
       return Float.parseFloat("".equals(toConvert) ? "0" : toConvert);

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FloatFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FloatFormatter.java
@@ -20,7 +20,7 @@ import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
 /**
  * Formatter for {@link Float} data
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class FloatFormatter extends AbstractDecimalFormatter<Float> {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FormatInstructionsBuilder.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FormatInstructionsBuilder.java
@@ -1,0 +1,82 @@
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.FixedFormatBoolean;
+import com.ancientprogramming.fixedformat4j.annotation.FixedFormatDecimal;
+import com.ancientprogramming.fixedformat4j.annotation.FixedFormatNumber;
+import com.ancientprogramming.fixedformat4j.annotation.FixedFormatPattern;
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+import com.ancientprogramming.fixedformat4j.format.FormatContext;
+import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
+import com.ancientprogramming.fixedformat4j.format.data.FixedFormatBooleanData;
+import com.ancientprogramming.fixedformat4j.format.data.FixedFormatDecimalData;
+import com.ancientprogramming.fixedformat4j.format.data.FixedFormatNumberData;
+import com.ancientprogramming.fixedformat4j.format.data.FixedFormatPatternData;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.math.RoundingMode;
+
+import static java.lang.String.format;
+
+/**
+ * Builds {@link FormatInstructions} and {@link FormatContext} from field annotations.
+ *
+ * @author Jacob von Eyben - https://eybenconsult.com
+ * @since 1.5.1
+ */
+class FormatInstructionsBuilder {
+
+  FormatInstructions build(AnnotatedElement annotationSource, Field fieldAnno) {
+    FixedFormatPatternData patternData = patternData(annotationSource.getAnnotation(FixedFormatPattern.class));
+    FixedFormatBooleanData booleanData = booleanData(annotationSource.getAnnotation(FixedFormatBoolean.class));
+    FixedFormatNumberData numberData = numberData(annotationSource.getAnnotation(FixedFormatNumber.class));
+    FixedFormatDecimalData decimalData = decimalData(annotationSource.getAnnotation(FixedFormatDecimal.class));
+    return new FormatInstructions(fieldAnno.length(), fieldAnno.align(), fieldAnno.paddingChar(), patternData, booleanData, numberData, decimalData);
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  FormatContext<?> context(Class<?> datatype, Field fieldAnno) {
+    if (fieldAnno != null) {
+      return new FormatContext(fieldAnno.offset(), datatype, fieldAnno.formatter());
+    }
+    return null;
+  }
+
+  Class<?> datatype(Method method, Field fieldAnno) {
+    if (method.getName().startsWith("get") || method.getName().startsWith("is")) {
+      return method.getReturnType();
+    }
+    throw new FixedFormatException(format(
+        "Cannot annotate method %s, with %s annotation. %s annotations must be placed on methods starting with 'get' or 'is'",
+        method.getName(), fieldAnno.getClass().getName(), fieldAnno.getClass().getName()));
+  }
+
+  private FixedFormatPatternData patternData(FixedFormatPattern annotation) {
+    if (annotation != null) {
+      return new FixedFormatPatternData(annotation.value());
+    }
+    return FixedFormatPatternData.DEFAULT;
+  }
+
+  private FixedFormatBooleanData booleanData(FixedFormatBoolean annotation) {
+    if (annotation != null) {
+      return new FixedFormatBooleanData(annotation.trueValue(), annotation.falseValue());
+    }
+    return FixedFormatBooleanData.DEFAULT;
+  }
+
+  private FixedFormatNumberData numberData(FixedFormatNumber annotation) {
+    if (annotation != null) {
+      return new FixedFormatNumberData(annotation.sign(), annotation.positiveSign(), annotation.negativeSign());
+    }
+    return FixedFormatNumberData.DEFAULT;
+  }
+
+  private FixedFormatDecimalData decimalData(FixedFormatDecimal annotation) {
+    if (annotation != null) {
+      return new FixedFormatDecimalData(annotation.decimals(), annotation.useDecimalDelimiter(), annotation.decimalDelimiter(), RoundingMode.valueOf(annotation.roundingMode()));
+    }
+    return FixedFormatDecimalData.DEFAULT;
+  }
+}

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FormatInstructionsBuilder.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FormatInstructionsBuilder.java
@@ -22,7 +22,7 @@ import static java.lang.String.format;
 /**
  * Builds {@link FormatInstructions} and {@link FormatContext} from field annotations.
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.5.1
  */
 class FormatInstructionsBuilder {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/IntegerFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/IntegerFormatter.java
@@ -25,10 +25,12 @@ import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
  */
 public class IntegerFormatter extends AbstractNumberFormatter<Integer> {
 
+  /** {@inheritDoc} */
   public Integer asObject(String string, FormatInstructions instructions) {
     return Integer.parseInt(string);
   }
 
+  /** {@inheritDoc} */
   public String asString(Integer obj, FormatInstructions instructions) {
     String result = null;
     if (obj != null) {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/IntegerFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/IntegerFormatter.java
@@ -20,7 +20,7 @@ import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
 /**
  * Formatter for {@link Integer} data
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class IntegerFormatter extends AbstractNumberFormatter<Integer> {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/LocalDateFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/LocalDateFormatter.java
@@ -43,7 +43,7 @@ public class LocalDateFormatter extends AbstractFixedFormatter<LocalDate> {
     try {
       return LocalDate.parse(string, DateTimeFormatter.ofPattern(pattern));
     } catch (DateTimeParseException e) {
-      throw new FixedFormatException("Could not parse value[" + string + "] by pattern[" + pattern + "] to " + LocalDate.class.getName());
+      throw new FixedFormatException(String.format("Could not parse value[%s] by pattern[%s] to %s", string, pattern, LocalDate.class.getName()));
     }
   }
 

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/LocalDateFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/LocalDateFormatter.java
@@ -35,6 +35,7 @@ import java.time.format.DateTimeParseException;
  */
 public class LocalDateFormatter extends AbstractFixedFormatter<LocalDate> {
 
+  /** {@inheritDoc} */
   public LocalDate asObject(String string, FormatInstructions instructions) throws FixedFormatException {
     if (StringUtils.isEmpty(string)) {
       return null;
@@ -47,6 +48,7 @@ public class LocalDateFormatter extends AbstractFixedFormatter<LocalDate> {
     }
   }
 
+  /** {@inheritDoc} */
   public String asString(LocalDate date, FormatInstructions instructions) {
     if (date == null) {
       return null;

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/LocalDateFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/LocalDateFormatter.java
@@ -30,7 +30,7 @@ import java.time.format.DateTimeParseException;
  * The pattern is configured via {@link com.ancientprogramming.fixedformat4j.annotation.FixedFormatPattern}.
  * The default pattern is {@code yyyyMMdd}.
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.4.0
  */
 public class LocalDateFormatter extends AbstractFixedFormatter<LocalDate> {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/LongFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/LongFormatter.java
@@ -26,10 +26,12 @@ import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
  */
 public class LongFormatter extends AbstractNumberFormatter<Long> {
 
+  /** {@inheritDoc} */
   public Long asObject(String string, FormatInstructions instructions) {
     return Long.parseLong(string);
   }
 
+  /** {@inheritDoc} */
   public String asString(Long obj, FormatInstructions instructions) {
     String result = null;
     if (obj != null) {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/LongFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/LongFormatter.java
@@ -21,7 +21,7 @@ import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
 /**
  * Formatter for {@link Long} data
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class LongFormatter extends AbstractNumberFormatter<Long> {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/RecordInstantiator.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/RecordInstantiator.java
@@ -1,0 +1,61 @@
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+
+import java.lang.reflect.Constructor;
+
+import static java.lang.String.format;
+
+/**
+ * Creates instances of {@code @Record}-annotated classes via reflection,
+ * including support for static nested classes and non-static inner classes.
+ *
+ * @author Jacob von Eyben - https://eybenconsult.com
+ * @since 1.5.1
+ */
+class RecordInstantiator {
+
+  <T> T instantiate(Class<T> fixedFormatRecordClass) {
+    try {
+      Constructor<T> constructor = fixedFormatRecordClass.getDeclaredConstructor();
+      return constructor.newInstance();
+    } catch (NoSuchMethodException e) {
+      Class<?> declaringClass = fixedFormatRecordClass.getDeclaringClass();
+      if (declaringClass != null) {
+        return instantiateInnerClass(fixedFormatRecordClass, declaringClass, e);
+      }
+      throw new FixedFormatException(format(
+          "%s is missing a default constructor which is nessesary to be loaded through %s",
+          fixedFormatRecordClass.getName(), getClass().getName()));
+    } catch (Exception e) {
+      throw new FixedFormatException(format("unable to create instance of %s", fixedFormatRecordClass.getName()), e);
+    }
+  }
+
+  private <T> T instantiateInnerClass(Class<T> innerClass, Class<?> declaringClass, Exception outerException) {
+    Object declaringClassInstance;
+    try {
+      Constructor<?> declaringClassConstructor = declaringClass.getDeclaredConstructor();
+      declaringClassInstance = declaringClassConstructor.newInstance();
+    } catch (NoSuchMethodException dex) {
+      throw new FixedFormatException(format(
+          "Trying to create instance of innerclass %s, but the declaring class %s is missing a default constructor which is nessesary to be loaded through %s",
+          innerClass.getName(), declaringClass.getName(), getClass().getName()));
+    } catch (Exception de) {
+      throw new FixedFormatException(format(
+          "unable to create instance of declaring class %s, which is needed to instansiate %s",
+          declaringClass.getName(), innerClass.getName()), outerException);
+    }
+
+    try {
+      Constructor<T> constructor = innerClass.getDeclaredConstructor(declaringClass);
+      return constructor.newInstance(declaringClassInstance);
+    } catch (NoSuchMethodException ex) {
+      throw new FixedFormatException(format(
+          "%s is missing a default constructor which is nessesary to be loaded through %s",
+          innerClass.getName(), getClass().getName()));
+    } catch (Exception ex) {
+      throw new FixedFormatException(format("unable to create instance of %s", innerClass.getName()), outerException);
+    }
+  }
+}

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/RecordInstantiator.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/RecordInstantiator.java
@@ -10,7 +10,7 @@ import static java.lang.String.format;
  * Creates instances of {@code @Record}-annotated classes via reflection,
  * including support for static nested classes and non-static inner classes.
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.5.1
  */
 class RecordInstantiator {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/RepeatingFieldSupport.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/RepeatingFieldSupport.java
@@ -31,7 +31,7 @@ import static java.lang.String.format;
 /**
  * Handles all {@code count > 1} (repeating) field logic for both reading and exporting.
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.5.1
  */
 class RepeatingFieldSupport {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/RepeatingFieldSupport.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/RepeatingFieldSupport.java
@@ -91,7 +91,7 @@ class RepeatingFieldSupport {
     int actualSize = value.getClass().isArray() ? Array.getLength(value) : ((Collection<?>) value).size();
 
     if (actualSize != count) {
-      if (fieldAnno.strictExportCount()) {
+      if (fieldAnno.strictCount()) {
         throw new FixedFormatException(
             format("Repeating field %s has count=%d but collection size=%d", fieldLabel(target.getter), count, actualSize));
       } else {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/RepeatingFieldSupport.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/RepeatingFieldSupport.java
@@ -1,0 +1,200 @@
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+import com.ancientprogramming.fixedformat4j.format.FixedFormatter;
+import com.ancientprogramming.fixedformat4j.format.FormatContext;
+import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
+import com.ancientprogramming.fixedformat4j.format.ParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static com.ancientprogramming.fixedformat4j.format.FixedFormatUtil.fetchData;
+import static com.ancientprogramming.fixedformat4j.format.FixedFormatUtil.getFixedFormatterInstance;
+
+/**
+ * Handles all {@code count > 1} (repeating) field logic for both reading and exporting.
+ *
+ * @author Jacob von Eyben - https://eybenconsult.com
+ * @since 1.5.1
+ */
+class RepeatingFieldSupport {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RepeatingFieldSupport.class);
+
+  private final FormatInstructionsBuilder instructionsBuilder = new FormatInstructionsBuilder();
+
+  // -------------------------------------------------------------------------
+  // Read
+  // -------------------------------------------------------------------------
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  Object read(Class<?> clazz, String data, Method getter, AnnotatedElement annotationSource, Field fieldAnno) {
+    int count = fieldAnno.count();
+    Class<?> elementType = resolveElementType(getter);
+    FormatInstructions formatdata = instructionsBuilder.build(annotationSource, fieldAnno);
+
+    FormatContext protoContext = new FormatContext(fieldAnno.offset(), elementType, fieldAnno.formatter());
+    FixedFormatter<Object> formatter = (FixedFormatter<Object>) getFixedFormatterInstance(protoContext.getFormatter(), protoContext);
+
+    List<Object> elements = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      int elementOffset = fieldAnno.offset() + fieldAnno.length() * i;
+      FormatContext elementContext = new FormatContext(elementOffset, elementType, fieldAnno.formatter());
+      String dataToParse = fetchData(data, formatdata, elementContext);
+      try {
+        elements.add(formatter.parse(dataToParse, formatdata));
+      } catch (RuntimeException e) {
+        throw new ParseException(data, dataToParse, clazz, getter, elementContext, formatdata, e);
+      }
+    }
+
+    return assembleCollection(getter, elements);
+  }
+
+  // -------------------------------------------------------------------------
+  // Export
+  // -------------------------------------------------------------------------
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  <T> void export(T fixedFormatRecord, AnnotationTarget target, Field fieldAnno, HashMap<Integer, String> foundData) {
+    validateCount(target.getter, fieldAnno);
+
+    Object value;
+    try {
+      value = target.getter.invoke(fixedFormatRecord);
+    } catch (Exception e) {
+      throw new FixedFormatException("could not invoke " + fieldLabel(target.getter), e);
+    }
+
+    if (value == null) {
+      throw new FixedFormatException("Cannot export null repeating field on " + fieldLabel(target.getter));
+    }
+
+    int count = fieldAnno.count();
+    int actualSize = value.getClass().isArray() ? Array.getLength(value) : ((Collection<?>) value).size();
+
+    if (actualSize != count) {
+      if (fieldAnno.strictExportCount()) {
+        throw new FixedFormatException(
+            "Repeating field " + fieldLabel(target.getter) + " has count=" + count
+            + " but collection size=" + actualSize);
+      } else {
+        LOG.warn("Repeating field {} has count={} but collection size={}. Exporting {} elements.",
+            fieldLabel(target.getter), count, actualSize, Math.min(count, actualSize));
+      }
+    }
+
+    int exportCount = Math.min(count, actualSize);
+    Class<?> elementType = resolveElementType(target.getter);
+    FormatInstructions formatdata = instructionsBuilder.build(target.annotationSource, fieldAnno);
+    FormatContext protoContext = new FormatContext(fieldAnno.offset(), elementType, fieldAnno.formatter());
+    FixedFormatter<Object> formatter = (FixedFormatter<Object>) getFixedFormatterInstance(protoContext.getFormatter(), protoContext);
+
+    Iterable<?> iterable = value.getClass().isArray() ? arrayToIterable(value, exportCount) : (Collection<?>) value;
+
+    int i = 0;
+    for (Object element : iterable) {
+      if (i >= exportCount) break;
+      int elementOffset = fieldAnno.offset() + fieldAnno.length() * i;
+      foundData.put(elementOffset, formatter.format(element, formatdata));
+      i++;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Validation & utilities — package-private for direct testing
+  // -------------------------------------------------------------------------
+
+  void validateCount(Method method, Field fieldAnnotation) {
+    int count = fieldAnnotation.count();
+    Class<?> returnType = method.getReturnType();
+    boolean isArrayOrCollection = returnType.isArray()
+        || Collection.class.isAssignableFrom(returnType)
+        || Iterable.class.isAssignableFrom(returnType);
+
+    if (count < 1) {
+      throw new FixedFormatException(
+          "@Field count must be >= 1 on " + fieldLabel(method) + ", was: " + count);
+    }
+    if (count == 1 && isArrayOrCollection) {
+      throw new FixedFormatException(
+          "@Field count=1 but return type is array/collection on " + fieldLabel(method)
+          + ". Use count > 1 for repeating fields.");
+    }
+    if (count > 1 && !isArrayOrCollection) {
+      throw new FixedFormatException(
+          "@Field count=" + count + " requires array or Collection return type on "
+          + fieldLabel(method) + ", found: " + returnType.getName());
+    }
+  }
+
+  Class<?> resolveElementType(Method method) {
+    Class<?> returnType = method.getReturnType();
+    if (returnType.isArray()) {
+      return returnType.getComponentType();
+    }
+    Type genericReturnType = method.getGenericReturnType();
+    if (genericReturnType instanceof ParameterizedType) {
+      ParameterizedType pt = (ParameterizedType) genericReturnType;
+      Type[] typeArgs = pt.getActualTypeArguments();
+      if (typeArgs.length > 0 && typeArgs[0] instanceof Class) {
+        return (Class<?>) typeArgs[0];
+      }
+    }
+    throw new FixedFormatException("Cannot determine element type for repeating field on " + fieldLabel(method)
+        + ". Ensure the collection is parameterized (e.g. List<String>, not List).");
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  Object assembleCollection(Method getter, List<Object> elements) {
+    Class<?> returnType = getter.getReturnType();
+    if (returnType.isArray()) {
+      Object array = Array.newInstance(returnType.getComponentType(), elements.size());
+      for (int i = 0; i < elements.size(); i++) {
+        Array.set(array, i, elements.get(i));
+      }
+      return array;
+    } else if (LinkedList.class.isAssignableFrom(returnType)) {
+      return new LinkedList<>(elements);
+    } else if (List.class.isAssignableFrom(returnType)) {
+      return new ArrayList<>(elements);
+    } else if (SortedSet.class.isAssignableFrom(returnType)) {
+      return new TreeSet<>(elements);
+    } else if (Set.class.isAssignableFrom(returnType)) {
+      return new LinkedHashSet<>(elements);
+    } else if (Collection.class.isAssignableFrom(returnType) || Iterable.class.isAssignableFrom(returnType)) {
+      return new ArrayList<>(elements);
+    } else {
+      throw new FixedFormatException("Unsupported collection type " + returnType.getName()
+          + " on " + fieldLabel(getter) + ". Supported types: arrays, List, LinkedList, Set, SortedSet, Collection.");
+    }
+  }
+
+  private Iterable<Object> arrayToIterable(Object array, int limit) {
+    List<Object> list = new ArrayList<>(limit);
+    for (int i = 0; i < limit; i++) {
+      list.add(Array.get(array, i));
+    }
+    return list;
+  }
+
+  private static String fieldLabel(Method method) {
+    return method.getDeclaringClass().getName() + "#" + method.getName() + "()";
+  }
+}

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/RepeatingFieldSupport.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/RepeatingFieldSupport.java
@@ -26,6 +26,7 @@ import java.util.TreeSet;
 
 import static com.ancientprogramming.fixedformat4j.format.FixedFormatUtil.fetchData;
 import static com.ancientprogramming.fixedformat4j.format.FixedFormatUtil.getFixedFormatterInstance;
+import static java.lang.String.format;
 
 /**
  * Handles all {@code count > 1} (repeating) field logic for both reading and exporting.
@@ -79,11 +80,11 @@ class RepeatingFieldSupport {
     try {
       value = target.getter.invoke(fixedFormatRecord);
     } catch (Exception e) {
-      throw new FixedFormatException("could not invoke " + fieldLabel(target.getter), e);
+      throw new FixedFormatException(format("could not invoke %s", fieldLabel(target.getter)), e);
     }
 
     if (value == null) {
-      throw new FixedFormatException("Cannot export null repeating field on " + fieldLabel(target.getter));
+      throw new FixedFormatException(format("Cannot export null repeating field on %s", fieldLabel(target.getter)));
     }
 
     int count = fieldAnno.count();
@@ -92,8 +93,7 @@ class RepeatingFieldSupport {
     if (actualSize != count) {
       if (fieldAnno.strictExportCount()) {
         throw new FixedFormatException(
-            "Repeating field " + fieldLabel(target.getter) + " has count=" + count
-            + " but collection size=" + actualSize);
+            format("Repeating field %s has count=%d but collection size=%d", fieldLabel(target.getter), count, actualSize));
       } else {
         LOG.warn("Repeating field {} has count={} but collection size={}. Exporting {} elements.",
             fieldLabel(target.getter), count, actualSize, Math.min(count, actualSize));
@@ -130,17 +130,15 @@ class RepeatingFieldSupport {
 
     if (count < 1) {
       throw new FixedFormatException(
-          "@Field count must be >= 1 on " + fieldLabel(method) + ", was: " + count);
+          format("@Field count must be >= 1 on %s, was: %d", fieldLabel(method), count));
     }
     if (count == 1 && isArrayOrCollection) {
       throw new FixedFormatException(
-          "@Field count=1 but return type is array/collection on " + fieldLabel(method)
-          + ". Use count > 1 for repeating fields.");
+          format("@Field count=1 but return type is array/collection on %s. Use count > 1 for repeating fields.", fieldLabel(method)));
     }
     if (count > 1 && !isArrayOrCollection) {
       throw new FixedFormatException(
-          "@Field count=" + count + " requires array or Collection return type on "
-          + fieldLabel(method) + ", found: " + returnType.getName());
+          format("@Field count=%d requires array or Collection return type on %s, found: %s", count, fieldLabel(method), returnType.getName()));
     }
   }
 
@@ -157,8 +155,7 @@ class RepeatingFieldSupport {
         return (Class<?>) typeArgs[0];
       }
     }
-    throw new FixedFormatException("Cannot determine element type for repeating field on " + fieldLabel(method)
-        + ". Ensure the collection is parameterized (e.g. List<String>, not List).");
+    throw new FixedFormatException(format("Cannot determine element type for repeating field on %s. Ensure the collection is parameterized (e.g. List<String>, not List).", fieldLabel(method)));
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})
@@ -181,8 +178,7 @@ class RepeatingFieldSupport {
     } else if (Collection.class.isAssignableFrom(returnType) || Iterable.class.isAssignableFrom(returnType)) {
       return new ArrayList<>(elements);
     } else {
-      throw new FixedFormatException("Unsupported collection type " + returnType.getName()
-          + " on " + fieldLabel(getter) + ". Supported types: arrays, List, LinkedList, Set, SortedSet, Collection.");
+      throw new FixedFormatException(format("Unsupported collection type %s on %s. Supported types: arrays, List, LinkedList, Set, SortedSet, Collection.", returnType.getName(), fieldLabel(getter)));
     }
   }
 
@@ -195,6 +191,6 @@ class RepeatingFieldSupport {
   }
 
   private static String fieldLabel(Method method) {
-    return method.getDeclaringClass().getName() + "#" + method.getName() + "()";
+    return format("%s#%s()", method.getDeclaringClass().getName(), method.getName());
   }
 }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ShortFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ShortFormatter.java
@@ -20,7 +20,7 @@ import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
 /**
  * Formatter for {@link Short} data
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.3.0
  */
 public class ShortFormatter extends AbstractNumberFormatter<Short> {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ShortFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ShortFormatter.java
@@ -25,10 +25,12 @@ import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
  */
 public class ShortFormatter extends AbstractNumberFormatter<Short> {
 
+  /** {@inheritDoc} */
   public Short asObject(String string, FormatInstructions instructions) {
     return Short.parseShort(string);
   }
 
+  /** {@inheritDoc} */
   public String asString(Short obj, FormatInstructions instructions) {
     String result = null;
     if (obj != null) {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/StringFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/StringFormatter.java
@@ -21,7 +21,7 @@ import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
 /**
  * Formatter for {@link String} data
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class StringFormatter extends AbstractFixedFormatter<String> {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/StringFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/StringFormatter.java
@@ -26,10 +26,12 @@ import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
  */
 public class StringFormatter extends AbstractFixedFormatter<String> {
 
+  /** {@inheritDoc} */
   public String asObject(String string, FormatInstructions instructions) {
     return string;
   }
 
+  /** {@inheritDoc} */
   public String asString(String string, FormatInstructions instructions) {
     String result = null;
     if (string != null) {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/annotation/TestAlign.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/annotation/TestAlign.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class TestAlign {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/TestFixedFormatUtil.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/TestFixedFormatUtil.java
@@ -20,7 +20,7 @@ import com.ancientprogramming.fixedformat4j.format.impl.StringFormatter;
 import org.junit.jupiter.api.Test;
 
 /**
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class TestFixedFormatUtil {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/MultibleFieldsRecord.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/MultibleFieldsRecord.java
@@ -24,7 +24,7 @@ import com.ancientprogramming.fixedformat4j.annotation.Record;
 import java.util.Date;
 
 /**
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 @Record

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/MyRecord.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/MyRecord.java
@@ -23,7 +23,7 @@ import java.util.Date;
 /**
  * A record used in testcases
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 @Record

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/RepeatingFieldCollectionRecord.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/RepeatingFieldCollectionRecord.java
@@ -1,0 +1,52 @@
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.annotation.Align;
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.Record;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Test fixture for repeating @Field with Collection return types.
+ *
+ * Layout (1-based offsets):
+ *   positions  1-15 : 3 x String via List&lt;String&gt; (length=5, LEFT aligned)
+ *   positions 16-25 : 2 x Integer via Collection&lt;Integer&gt; (length=5, RIGHT aligned, zero-padded)
+ *   positions 26-37 : 3 x String via Set&lt;String&gt; (length=4, LEFT aligned) — loaded as LinkedHashSet
+ */
+@Record
+public class RepeatingFieldCollectionRecord {
+
+  private List<String> codes;
+  private Collection<Integer> amounts;
+  private Set<String> tags;
+
+  @Field(offset = 1, length = 5, count = 3)
+  public List<String> getCodes() {
+    return codes;
+  }
+
+  public void setCodes(List<String> codes) {
+    this.codes = codes;
+  }
+
+  @Field(offset = 16, length = 5, count = 2, align = Align.RIGHT, paddingChar = '0')
+  public Collection<Integer> getAmounts() {
+    return amounts;
+  }
+
+  public void setAmounts(Collection<Integer> amounts) {
+    this.amounts = amounts;
+  }
+
+  @Field(offset = 26, length = 4, count = 3)
+  public Set<String> getTags() {
+    return tags;
+  }
+
+  public void setTags(Set<String> tags) {
+    this.tags = tags;
+  }
+}

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/RepeatingFieldRecord.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/RepeatingFieldRecord.java
@@ -1,0 +1,37 @@
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.Record;
+import com.ancientprogramming.fixedformat4j.annotation.Align;
+
+/**
+ * Test fixture for repeating @Field with array return types.
+ *
+ * Layout (1-based offsets):
+ *   positions  1-15 : 3 x String (length=5, LEFT aligned, space-padded)
+ *   positions 16-25 : 2 x Integer (length=5, RIGHT aligned, zero-padded)
+ */
+@Record
+public class RepeatingFieldRecord {
+
+  private String[] codes;
+  private Integer[] amounts;
+
+  @Field(offset = 1, length = 5, count = 3)
+  public String[] getCodes() {
+    return codes;
+  }
+
+  public void setCodes(String[] codes) {
+    this.codes = codes;
+  }
+
+  @Field(offset = 16, length = 5, count = 2, align = Align.RIGHT, paddingChar = '0')
+  public Integer[] getAmounts() {
+    return amounts;
+  }
+
+  public void setAmounts(Integer[] amounts) {
+    this.amounts = amounts;
+  }
+}

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestAnnotationScanner.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestAnnotationScanner.java
@@ -1,0 +1,127 @@
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.Fields;
+import com.ancientprogramming.fixedformat4j.annotation.Record;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestAnnotationScanner {
+
+  private final AnnotationScanner scanner = new AnnotationScanner();
+
+  @Test
+  void scan_methodAnnotation_returnsTarget() {
+    List<AnnotationTarget> targets = scanner.scan(MethodAnnotatedRecord.class);
+    assertEquals(1, targets.size());
+    assertEquals("getValue", targets.get(0).getter.getName());
+    assertNotNull(targets.get(0).annotationSource.getAnnotation(Field.class));
+  }
+
+  @Test
+  void scan_fieldAnnotation_returnsTarget() {
+    List<AnnotationTarget> targets = scanner.scan(FieldAnnotatedRecord.class);
+    assertEquals(1, targets.size());
+    assertEquals("getValue", targets.get(0).getter.getName());
+    assertNotNull(targets.get(0).annotationSource.getAnnotation(Field.class));
+  }
+
+  @Test
+  void scan_fieldAndMethodAnnotation_fieldTakesPriority() {
+    List<AnnotationTarget> targets = scanner.scan(BothAnnotatedRecord.class);
+    assertEquals(1, targets.size());
+    assertInstanceOf(java.lang.reflect.Field.class, targets.get(0).annotationSource);
+  }
+
+  @Test
+  void scan_fieldsAnnotation_returnsTarget() {
+    List<AnnotationTarget> targets = scanner.scan(FieldsAnnotatedRecord.class);
+    assertEquals(1, targets.size());
+    assertNotNull(targets.get(0).annotationSource.getAnnotation(Fields.class));
+  }
+
+  @Test
+  void scan_superclassFields_included() {
+    List<AnnotationTarget> targets = scanner.scan(SubRecord.class);
+    boolean hasBaseField = targets.stream().anyMatch(t -> t.getter.getName().equals("getBaseValue"));
+    assertTrue(hasBaseField, "Expected field from superclass to be included");
+  }
+
+  @Test
+  void scan_orderPreserved() {
+    List<AnnotationTarget> targets = scanner.scan(MultiFieldRecord.class);
+    assertEquals(2, targets.size());
+    assertEquals("getFirst", targets.get(0).getter.getName());
+    assertEquals("getSecond", targets.get(1).getter.getName());
+  }
+
+  // --- Fixture classes ---
+
+  @Record
+  static class MethodAnnotatedRecord {
+    private String value;
+
+    @Field(offset = 1, length = 5)
+    public String getValue() { return value; }
+    public void setValue(String v) { this.value = v; }
+  }
+
+  @Record
+  static class FieldAnnotatedRecord {
+    @Field(offset = 1, length = 5)
+    private String value;
+
+    public String getValue() { return value; }
+    public void setValue(String v) { this.value = v; }
+  }
+
+  @Record
+  static class BothAnnotatedRecord {
+    @Field(offset = 1, length = 5)
+    private String value;
+
+    @Field(offset = 1, length = 5)
+    public String getValue() { return value; }
+    public void setValue(String v) { this.value = v; }
+  }
+
+  @Record
+  static class FieldsAnnotatedRecord {
+    private String value;
+
+    @Fields({@Field(offset = 1, length = 5)})
+    public String getValue() { return value; }
+    public void setValue(String v) { this.value = v; }
+  }
+
+  @Record
+  static class BaseRecord {
+    @Field(offset = 1, length = 5)
+    private String baseValue;
+
+    public String getBaseValue() { return baseValue; }
+    public void setBaseValue(String v) { this.baseValue = v; }
+  }
+
+  @Record
+  static class SubRecord extends BaseRecord {
+  }
+
+  @Record
+  static class MultiFieldRecord {
+    @Field(offset = 1, length = 5)
+    private String first;
+
+    @Field(offset = 6, length = 5)
+    private String second;
+
+    public String getFirst() { return first; }
+    public void setFirst(String v) { this.first = v; }
+
+    public String getSecond() { return second; }
+    public void setSecond(String v) { this.second = v; }
+  }
+}

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestBigDecimalFormatter.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestBigDecimalFormatter.java
@@ -31,7 +31,7 @@ import static com.ancientprogramming.fixedformat4j.annotation.FixedFormatNumber.
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class TestBigDecimalFormatter {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestBooleanFormatter.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestBooleanFormatter.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class TestBooleanFormatter {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestCharacterFormatter.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestCharacterFormatter.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class TestCharacterFormatter {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestDateFormatter.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestDateFormatter.java
@@ -27,7 +27,7 @@ import java.util.Date;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class TestDateFormatter {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestDoubleFormatter.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestDoubleFormatter.java
@@ -29,7 +29,7 @@ import static com.ancientprogramming.fixedformat4j.annotation.FixedFormatNumber.
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class TestDoubleFormatter {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestFixedFormatManagerImpl.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestFixedFormatManagerImpl.java
@@ -33,7 +33,7 @@ import java.util.Calendar;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class TestFixedFormatManagerImpl {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestFloatFormatter.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestFloatFormatter.java
@@ -29,7 +29,7 @@ import static com.ancientprogramming.fixedformat4j.annotation.FixedFormatNumber.
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class TestFloatFormatter {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestFormatInstructionsBuilder.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestFormatInstructionsBuilder.java
@@ -1,0 +1,141 @@
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.FixedFormatBoolean;
+import com.ancientprogramming.fixedformat4j.annotation.FixedFormatDecimal;
+import com.ancientprogramming.fixedformat4j.annotation.FixedFormatNumber;
+import com.ancientprogramming.fixedformat4j.annotation.FixedFormatPattern;
+import com.ancientprogramming.fixedformat4j.annotation.Record;
+import com.ancientprogramming.fixedformat4j.annotation.Sign;
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+import com.ancientprogramming.fixedformat4j.format.FormatContext;
+import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
+import com.ancientprogramming.fixedformat4j.format.data.FixedFormatBooleanData;
+import com.ancientprogramming.fixedformat4j.format.data.FixedFormatDecimalData;
+import com.ancientprogramming.fixedformat4j.format.data.FixedFormatNumberData;
+import com.ancientprogramming.fixedformat4j.format.data.FixedFormatPatternData;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestFormatInstructionsBuilder {
+
+  private final FormatInstructionsBuilder builder = new FormatInstructionsBuilder();
+
+  @Test
+  void build_defaultAnnotations_returnsDefaultData() throws Exception {
+    Method getter = SimpleRecord.class.getMethod("getValue");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    FormatInstructions instructions = builder.build(getter, fieldAnno);
+    assertSame(FixedFormatPatternData.DEFAULT, instructions.getFixedFormatPatternData());
+    assertSame(FixedFormatBooleanData.DEFAULT, instructions.getFixedFormatBooleanData());
+    assertSame(FixedFormatNumberData.DEFAULT, instructions.getFixedFormatNumberData());
+    assertSame(FixedFormatDecimalData.DEFAULT, instructions.getFixedFormatDecimalData());
+  }
+
+  @Test
+  void build_withFixedFormatPattern_capturesPattern() throws Exception {
+    Method getter = PatternRecord.class.getMethod("getValue");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    FormatInstructions instructions = builder.build(getter, fieldAnno);
+    assertEquals("yyyyMMdd", instructions.getFixedFormatPatternData().getPattern());
+  }
+
+  @Test
+  void build_withFixedFormatBoolean_capturesTrueFalseValues() throws Exception {
+    Method getter = BoolRecord.class.getMethod("getValue");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    FormatInstructions instructions = builder.build(getter, fieldAnno);
+    assertEquals("Y", instructions.getFixedFormatBooleanData().getTrueValue());
+    assertEquals("N", instructions.getFixedFormatBooleanData().getFalseValue());
+  }
+
+  @Test
+  void build_withFixedFormatNumber_capturesSignConfig() throws Exception {
+    Method getter = NumberRecord.class.getMethod("getValue");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    FormatInstructions instructions = builder.build(getter, fieldAnno);
+    assertEquals(Sign.PREPEND, instructions.getFixedFormatNumberData().getSigning());
+  }
+
+  @Test
+  void build_withFixedFormatDecimal_capturesDecimals() throws Exception {
+    Method getter = DecimalRecord.class.getMethod("getValue");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    FormatInstructions instructions = builder.build(getter, fieldAnno);
+    assertEquals(2, instructions.getFixedFormatDecimalData().getDecimals());
+  }
+
+  @Test
+  void context_fromFieldAnnotation_hasCorrectOffsetAndType() throws Exception {
+    Method getter = SimpleRecord.class.getMethod("getValue");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    FormatContext<?> context = builder.context(String.class, fieldAnno);
+    assertEquals(5, context.getOffset());
+    assertEquals(String.class, context.getDataType());
+  }
+
+  @Test
+  void datatype_beanStandardMethod_returnsReturnType() throws Exception {
+    Method getter = SimpleRecord.class.getMethod("getValue");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    assertEquals(String.class, builder.datatype(getter, fieldAnno));
+  }
+
+  @Test
+  void datatype_nonBeanStandardMethod_throwsFixedFormatException() throws Exception {
+    Method nonGetter = NonGetterRecord.class.getMethod("fetch");
+    Field fieldAnno = nonGetter.getAnnotation(Field.class);
+    assertThrows(FixedFormatException.class, () -> builder.datatype(nonGetter, fieldAnno));
+  }
+
+  // --- Fixture classes ---
+
+  @Record
+  static class SimpleRecord {
+    @Field(offset = 5, length = 3)
+    public String getValue() { return null; }
+    public void setValue(String v) {}
+  }
+
+  @Record
+  static class PatternRecord {
+    @Field(offset = 1, length = 8)
+    @FixedFormatPattern("yyyyMMdd")
+    public String getValue() { return null; }
+    public void setValue(String v) {}
+  }
+
+  @Record
+  static class BoolRecord {
+    @Field(offset = 1, length = 1)
+    @FixedFormatBoolean(trueValue = "Y", falseValue = "N")
+    public Boolean getValue() { return null; }
+    public void setValue(Boolean v) {}
+  }
+
+  @Record
+  static class NumberRecord {
+    @Field(offset = 1, length = 10)
+    @FixedFormatNumber(sign = Sign.PREPEND)
+    public Integer getValue() { return null; }
+    public void setValue(Integer v) {}
+  }
+
+  @Record
+  static class DecimalRecord {
+    @Field(offset = 1, length = 10)
+    @FixedFormatDecimal(decimals = 2)
+    public BigDecimal getValue() { return null; }
+    public void setValue(BigDecimal v) {}
+  }
+
+  @Record
+  static class NonGetterRecord {
+    @Field(offset = 1, length = 5)
+    public String fetch() { return null; }
+  }
+}

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestIntegerFormatter.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestIntegerFormatter.java
@@ -30,7 +30,7 @@ import static com.ancientprogramming.fixedformat4j.annotation.FixedFormatNumber.
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class TestIntegerFormatter {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestLongFormatter.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestLongFormatter.java
@@ -30,7 +30,7 @@ import static com.ancientprogramming.fixedformat4j.annotation.FixedFormatNumber.
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class TestLongFormatter {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestRecordInstantiator.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestRecordInstantiator.java
@@ -1,0 +1,88 @@
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.Record;
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestRecordInstantiator {
+
+  private final RecordInstantiator instantiator = new RecordInstantiator();
+
+  @Test
+  void instantiate_plainClass_returnsNewInstance() {
+    PlainRecord instance = instantiator.instantiate(PlainRecord.class);
+    assertNotNull(instance);
+  }
+
+  @Test
+  void instantiate_staticNestedClass_returnsNewInstance() {
+    StaticNestedRecord instance = instantiator.instantiate(StaticNestedRecord.class);
+    assertNotNull(instance);
+  }
+
+  @Test
+  void instantiate_innerClass_returnsNewInstance() {
+    InnerClassHost.InnerRecord instance = instantiator.instantiate(InnerClassHost.InnerRecord.class);
+    assertNotNull(instance);
+  }
+
+  @Test
+  void instantiate_missingDefaultConstructor_throwsFixedFormatException() {
+    assertThrows(FixedFormatException.class,
+        () -> instantiator.instantiate(NoDefaultConstructorRecord.class));
+  }
+
+  @Test
+  void instantiate_declaringClassMissingDefaultConstructor_throwsFixedFormatException() {
+    assertThrows(FixedFormatException.class,
+        () -> instantiator.instantiate(NoDefaultConstructorHost.InnerRecord.class));
+  }
+
+  // --- Fixture classes ---
+
+  @Record
+  public static class PlainRecord {
+    @Field(offset = 1, length = 5)
+    public String getValue() { return null; }
+    public void setValue(String v) {}
+  }
+
+  @Record
+  public static class StaticNestedRecord {
+    @Field(offset = 1, length = 5)
+    public String getValue() { return null; }
+    public void setValue(String v) {}
+  }
+
+  public static class InnerClassHost {
+    @Record
+    public class InnerRecord {
+      @Field(offset = 1, length = 5)
+      public String getValue() { return null; }
+      public void setValue(String v) {}
+    }
+  }
+
+  @Record
+  public static class NoDefaultConstructorRecord {
+    public NoDefaultConstructorRecord(String required) {}
+
+    @Field(offset = 1, length = 5)
+    public String getValue() { return null; }
+    public void setValue(String v) {}
+  }
+
+  public static class NoDefaultConstructorHost {
+    public NoDefaultConstructorHost(String required) {}
+
+    @Record
+    public class InnerRecord {
+      @Field(offset = 1, length = 5)
+      public String getValue() { return null; }
+      public void setValue(String v) {}
+    }
+  }
+}

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestRepeatingField.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestRepeatingField.java
@@ -99,7 +99,7 @@ public class TestRepeatingField {
   }
 
   // -----------------------------------------------------------------------
-  // Lenient export fixtures (strictExportCount = false)
+  // Lenient export fixtures (strictCount = false)
   // -----------------------------------------------------------------------
 
   @Record
@@ -107,11 +107,11 @@ public class TestRepeatingField {
     private String[] codes;
     private Integer[] amounts;
 
-    @Field(offset = 1, length = 5, count = 3, strictExportCount = false)
+    @Field(offset = 1, length = 5, count = 3, strictCount = false)
     public String[] getCodes() { return codes; }
     public void setCodes(String[] codes) { this.codes = codes; }
 
-    @Field(offset = 16, length = 5, count = 2, align = Align.RIGHT, paddingChar = '0', strictExportCount = false)
+    @Field(offset = 16, length = 5, count = 2, align = Align.RIGHT, paddingChar = '0', strictCount = false)
     public Integer[] getAmounts() { return amounts; }
     public void setAmounts(Integer[] amounts) { this.amounts = amounts; }
   }
@@ -120,7 +120,7 @@ public class TestRepeatingField {
   static class LenientListRecord {
     private List<String> codes;
 
-    @Field(offset = 1, length = 5, count = 3, strictExportCount = false)
+    @Field(offset = 1, length = 5, count = 3, strictCount = false)
     public List<String> getCodes() { return codes; }
     public void setCodes(List<String> codes) { this.codes = codes; }
   }
@@ -375,7 +375,7 @@ public class TestRepeatingField {
   }
 
   // -----------------------------------------------------------------------
-  // Lenient export count (strictExportCount=false) — size mismatch logs WARN
+  // Lenient export count (strictCount=false) — size mismatch logs WARN
   // -----------------------------------------------------------------------
 
   private ListAppender<ILoggingEvent> attachLogCapture() {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestRepeatingField.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestRepeatingField.java
@@ -379,7 +379,7 @@ public class TestRepeatingField {
   // -----------------------------------------------------------------------
 
   private ListAppender<ILoggingEvent> attachLogCapture() {
-    Logger logger = (Logger) LoggerFactory.getLogger(FixedFormatManagerImpl.class);
+    Logger logger = (Logger) LoggerFactory.getLogger(RepeatingFieldSupport.class);
     ListAppender<ILoggingEvent> appender = new ListAppender<>();
     appender.start();
     logger.addAppender(appender);
@@ -388,7 +388,7 @@ public class TestRepeatingField {
   }
 
   private void detachLogCapture(ListAppender<ILoggingEvent> appender) {
-    Logger logger = (Logger) LoggerFactory.getLogger(FixedFormatManagerImpl.class);
+    Logger logger = (Logger) LoggerFactory.getLogger(RepeatingFieldSupport.class);
     logger.detachAppender(appender);
   }
 

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestRepeatingField.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestRepeatingField.java
@@ -1,0 +1,477 @@
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.ancientprogramming.fixedformat4j.annotation.Align;
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.Record;
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for @Field count — repeating fields mapped to arrays and collections.
+ *
+ * <p>String fields use LEFT alignment with space padding (default), so trailing spaces are
+ * stripped on load. Test values are stored as trimmed strings; export re-pads them.</p>
+ */
+public class TestRepeatingField {
+
+  // -----------------------------------------------------------------------
+  // Record data constants
+  //
+  // RepeatingFieldRecord layout (1-based):
+  //   positions  1- 5 : codes[0] — String, length 5, LEFT aligned, space-padded
+  //   positions  6-10 : codes[1]
+  //   positions 11-15 : codes[2]
+  //   positions 16-20 : amounts[0] — Integer, length 5, RIGHT aligned, zero-padded
+  //   positions 21-25 : amounts[1]
+  //
+  // Loaded string values are trimmed (trailing padding chars stripped by LEFT.remove).
+  // -----------------------------------------------------------------------
+  private static final String ARRAY_RECORD_DATA = "ab   cd   ef   0004200099";
+
+  // RepeatingFieldCollectionRecord layout (1-based):
+  //   positions  1-15 : 3 × String[5] codes
+  //   positions 16-25 : 2 × Integer[5] amounts (RIGHT, zero-padded)
+  //   positions 26-29 : tags[0] — String, length 4
+  //   positions 30-33 : tags[1]
+  //   positions 34-37 : tags[2]
+  //
+  // NOTE: no spaces between tag slots — contiguous 4-char fields.
+  private static final String COLLECTION_RECORD_DATA = "ab   cd   ef   0004200099aaaabbbbcccc";
+
+  private FixedFormatManager manager;
+
+  @BeforeEach
+  public void setUp() {
+    manager = new FixedFormatManagerImpl();
+  }
+
+  // =========================================================================
+  // Static nested record fixtures for validation-error tests
+  // (Static nested classes can be instantiated by FixedFormatManagerImpl
+  //  without an enclosing instance, unlike local classes in test methods.)
+  // =========================================================================
+
+  @Record
+  static class CountNegativeRecord {
+    private String value;
+    @Field(offset = 1, length = 5, count = -1)
+    public String getValue() { return value; }
+    public void setValue(String v) { this.value = v; }
+  }
+
+  @Record
+  static class CountZeroRecord {
+    private String value;
+    @Field(offset = 1, length = 5, count = 0)
+    public String getValue() { return value; }
+    public void setValue(String v) { this.value = v; }
+  }
+
+  @Record
+  static class CountOneArrayRecord {
+    private String[] values;
+    @Field(offset = 1, length = 5) // count=1 default, but return type is array
+    public String[] getValues() { return values; }
+    public void setValues(String[] v) { this.values = v; }
+  }
+
+  @Record
+  static class CountManyScalarRecord {
+    private String value;
+    @Field(offset = 1, length = 5, count = 3)
+    public String getValue() { return value; }
+    public void setValue(String v) { this.value = v; }
+  }
+
+  // -----------------------------------------------------------------------
+  // Lenient export fixtures (strictExportCount = false)
+  // -----------------------------------------------------------------------
+
+  @Record
+  static class LenientRecord {
+    private String[] codes;
+    private Integer[] amounts;
+
+    @Field(offset = 1, length = 5, count = 3, strictExportCount = false)
+    public String[] getCodes() { return codes; }
+    public void setCodes(String[] codes) { this.codes = codes; }
+
+    @Field(offset = 16, length = 5, count = 2, align = Align.RIGHT, paddingChar = '0', strictExportCount = false)
+    public Integer[] getAmounts() { return amounts; }
+    public void setAmounts(Integer[] amounts) { this.amounts = amounts; }
+  }
+
+  @Record
+  static class LenientListRecord {
+    private List<String> codes;
+
+    @Field(offset = 1, length = 5, count = 3, strictExportCount = false)
+    public List<String> getCodes() { return codes; }
+    public void setCodes(List<String> codes) { this.codes = codes; }
+  }
+
+  // =========================================================================
+  // Sunshine — arrays
+  // =========================================================================
+
+  @Test
+  public void testLoadStringArray() {
+    RepeatingFieldRecord record = manager.load(RepeatingFieldRecord.class, ARRAY_RECORD_DATA);
+    assertNotNull(record.getCodes());
+    assertEquals(3, record.getCodes().length);
+    // LEFT-aligned strings have trailing padding stripped on load
+    assertEquals("ab", record.getCodes()[0]);
+    assertEquals("cd", record.getCodes()[1]);
+    assertEquals("ef", record.getCodes()[2]);
+  }
+
+  @Test
+  public void testLoadIntegerArray() {
+    RepeatingFieldRecord record = manager.load(RepeatingFieldRecord.class, ARRAY_RECORD_DATA);
+    assertNotNull(record.getAmounts());
+    assertEquals(2, record.getAmounts().length);
+    assertEquals(42, record.getAmounts()[0]);
+    assertEquals(99, record.getAmounts()[1]);
+  }
+
+  @Test
+  public void testExportStringArray() {
+    RepeatingFieldRecord record = new RepeatingFieldRecord();
+    // Formatter pads "ab" to "ab   " (length 5, LEFT aligned)
+    record.setCodes(new String[]{"ab", "cd", "ef"});
+    record.setAmounts(new Integer[]{42, 99});
+    assertEquals(ARRAY_RECORD_DATA, manager.export(record));
+  }
+
+  @Test
+  public void testExportIntegerArray() {
+    RepeatingFieldRecord record = new RepeatingFieldRecord();
+    record.setCodes(new String[]{"xx", "yy", "zz"});
+    record.setAmounts(new Integer[]{1, 2});
+    String exported = manager.export(record);
+    // positions 16-20 (0-based 15-19) = "00001", positions 21-25 (0-based 20-24) = "00002"
+    assertEquals("00001", exported.substring(15, 20));
+    assertEquals("00002", exported.substring(20, 25));
+  }
+
+  @Test
+  public void testRoundTripStringArray() {
+    RepeatingFieldRecord original = new RepeatingFieldRecord();
+    original.setCodes(new String[]{"abc", "def", "ghi"});
+    original.setAmounts(new Integer[]{100, 200});
+    String exported = manager.export(original);
+    RepeatingFieldRecord loaded = manager.load(RepeatingFieldRecord.class, exported);
+    assertArrayEquals(original.getCodes(), loaded.getCodes());
+    assertArrayEquals(original.getAmounts(), loaded.getAmounts());
+  }
+
+  @Test
+  public void testRoundTripIntegerArray() {
+    RepeatingFieldRecord original = new RepeatingFieldRecord();
+    original.setCodes(new String[]{"a", "b", "c"});
+    original.setAmounts(new Integer[]{12345, 67890});
+    String exported = manager.export(original);
+    RepeatingFieldRecord loaded = manager.load(RepeatingFieldRecord.class, exported);
+    assertArrayEquals(original.getAmounts(), loaded.getAmounts());
+  }
+
+  // =========================================================================
+  // Sunshine — collections
+  // =========================================================================
+
+  @Test
+  public void testLoadStringList() {
+    RepeatingFieldCollectionRecord record = manager.load(RepeatingFieldCollectionRecord.class, COLLECTION_RECORD_DATA);
+    assertNotNull(record.getCodes());
+    assertEquals(3, record.getCodes().size());
+    // Trailing padding stripped by LEFT.remove
+    assertEquals("ab", record.getCodes().get(0));
+    assertEquals("cd", record.getCodes().get(1));
+    assertEquals("ef", record.getCodes().get(2));
+  }
+
+  @Test
+  public void testLoadIntegerCollection() {
+    RepeatingFieldCollectionRecord record = manager.load(RepeatingFieldCollectionRecord.class, COLLECTION_RECORD_DATA);
+    assertNotNull(record.getAmounts());
+    assertEquals(2, record.getAmounts().size());
+    List<Integer> amounts = new java.util.ArrayList<>(record.getAmounts());
+    assertEquals(42, amounts.get(0));
+    assertEquals(99, amounts.get(1));
+  }
+
+  @Test
+  public void testLoadStringLinkedHashSet() {
+    RepeatingFieldCollectionRecord record = manager.load(RepeatingFieldCollectionRecord.class, COLLECTION_RECORD_DATA);
+    assertNotNull(record.getTags());
+    assertEquals(3, record.getTags().size());
+    assertTrue(record.getTags() instanceof LinkedHashSet, "Expected LinkedHashSet");
+    // Insertion order preserved — tags are exact 4-char fields with no trailing spaces
+    List<String> tags = new java.util.ArrayList<>(record.getTags());
+    assertEquals("aaaa", tags.get(0));
+    assertEquals("bbbb", tags.get(1));
+    assertEquals("cccc", tags.get(2));
+  }
+
+  @Test
+  public void testExportStringList() {
+    RepeatingFieldCollectionRecord record = new RepeatingFieldCollectionRecord();
+    record.setCodes(Arrays.asList("ab", "cd", "ef"));
+    record.setAmounts(Arrays.asList(42, 99));
+    record.setTags(new LinkedHashSet<>(Arrays.asList("aaaa", "bbbb", "cccc")));
+    assertEquals(COLLECTION_RECORD_DATA, manager.export(record));
+  }
+
+  @Test
+  public void testExportLinkedHashSet() {
+    RepeatingFieldCollectionRecord record = new RepeatingFieldCollectionRecord();
+    record.setCodes(Arrays.asList("a", "b", "c"));
+    record.setAmounts(Arrays.asList(0, 0));
+    Set<String> tags = new LinkedHashSet<>(Arrays.asList("xxxx", "yyyy", "zzzz"));
+    record.setTags(tags);
+    String exported = manager.export(record);
+    // positions 26-29 (0-based 25-28) = "xxxx"
+    assertEquals("xxxx", exported.substring(25, 29));
+    assertEquals("yyyy", exported.substring(29, 33));
+    assertEquals("zzzz", exported.substring(33, 37));
+  }
+
+  @Test
+  public void testRoundTripStringList() {
+    RepeatingFieldCollectionRecord original = new RepeatingFieldCollectionRecord();
+    original.setCodes(Arrays.asList("abc", "def", "ghi"));
+    original.setAmounts(Arrays.asList(11, 22));
+    original.setTags(new LinkedHashSet<>(Arrays.asList("t1  ", "t2  ", "t3  ")));
+    String exported = manager.export(original);
+    RepeatingFieldCollectionRecord loaded = manager.load(RepeatingFieldCollectionRecord.class, exported);
+    assertEquals(original.getCodes(), loaded.getCodes());
+    assertEquals(new java.util.ArrayList<>(original.getAmounts()), new java.util.ArrayList<>(loaded.getAmounts()));
+  }
+
+  @Test
+  public void testRoundTripLinkedHashSet() {
+    RepeatingFieldCollectionRecord original = new RepeatingFieldCollectionRecord();
+    original.setCodes(Arrays.asList("a", "b", "c"));
+    original.setAmounts(Arrays.asList(0, 0));
+    // Use values with no trailing spaces so round-trip is exact after LEFT-strip
+    original.setTags(new LinkedHashSet<>(Arrays.asList("aaa", "bbb", "ccc")));
+    String exported = manager.export(original);
+    RepeatingFieldCollectionRecord loaded = manager.load(RepeatingFieldCollectionRecord.class, exported);
+    // Loaded as LinkedHashSet — order and values must match
+    assertEquals(new java.util.ArrayList<>(original.getTags()), new java.util.ArrayList<>(loaded.getTags()));
+  }
+
+  // =========================================================================
+  // Sunshine — backward compat (count=1, default)
+  // =========================================================================
+
+  @Test
+  public void testCountOneBackwardCompat() {
+    String data = "some text 0012320080514CT001100000010350000002056-0012 01200000002056";
+    MyRecord record = manager.load(MyRecord.class, data);
+    assertNotNull(record);
+    assertEquals(123, record.getIntegerData());
+  }
+
+  // =========================================================================
+  // Corner / validation — error messages must contain class + method name
+  // =========================================================================
+
+  @Test
+  public void testNegativeCountThrows() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.load(CountNegativeRecord.class, "hello"));
+    assertTrue(ex.getMessage().contains("getValue"), "Error must contain method name, got: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains("count"), "Error must mention count, got: " + ex.getMessage());
+  }
+
+  @Test
+  public void testCountZeroThrows() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.load(CountZeroRecord.class, "hello"));
+    assertTrue(ex.getMessage().contains("getValue"), "Error must contain method name, got: " + ex.getMessage());
+  }
+
+  @Test
+  public void testCountOneWithArrayTypeThrows() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.load(CountOneArrayRecord.class, "hello"));
+    assertTrue(ex.getMessage().contains("getValues"), "Error must contain method name, got: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains("count=1"), "Error must mention count=1, got: " + ex.getMessage());
+  }
+
+  @Test
+  public void testCountManyWithScalarTypeThrows() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.load(CountManyScalarRecord.class, "helloworld     "));
+    assertTrue(ex.getMessage().contains("getValue"), "Error must contain method name, got: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains("count=3"), "Error must mention count=3, got: " + ex.getMessage());
+  }
+
+  @Test
+  public void testExportNullArrayThrows() {
+    RepeatingFieldRecord record = new RepeatingFieldRecord();
+    record.setCodes(null);
+    record.setAmounts(new Integer[]{1, 2});
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.export(record));
+    assertTrue(ex.getMessage().contains("getCodes"), "Error must contain method name, got: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains("null"), "Error must mention null, got: " + ex.getMessage());
+  }
+
+  @Test
+  public void testExportNullListThrows() {
+    RepeatingFieldCollectionRecord record = new RepeatingFieldCollectionRecord();
+    record.setCodes(null);
+    record.setAmounts(Arrays.asList(1, 2));
+    record.setTags(new LinkedHashSet<>(Arrays.asList("a", "b", "c")));
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.export(record));
+    assertTrue(ex.getMessage().contains("getCodes"), "Error must contain method name, got: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains("null"), "Error must mention null, got: " + ex.getMessage());
+  }
+
+  // -----------------------------------------------------------------------
+  // Strict export count (default = true) — size mismatch must throw
+  // -----------------------------------------------------------------------
+
+  @Test
+  public void testExportArrayShorterThanCountStrictThrows() {
+    RepeatingFieldRecord record = new RepeatingFieldRecord();
+    record.setCodes(new String[]{"ab", "cd"}); // 2 elements, count=3
+    record.setAmounts(new Integer[]{1, 2});
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.export(record));
+    assertTrue(ex.getMessage().contains("getCodes"), "Error must contain method name, got: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains("count=3"), "Error must mention expected count, got: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains("size=2"), "Error must mention actual size, got: " + ex.getMessage());
+  }
+
+  @Test
+  public void testExportArrayLongerThanCountStrictThrows() {
+    RepeatingFieldRecord record = new RepeatingFieldRecord();
+    record.setCodes(new String[]{"ab", "cd", "ef", "gh"}); // 4 elements, count=3
+    record.setAmounts(new Integer[]{1, 2});
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.export(record));
+    assertTrue(ex.getMessage().contains("getCodes"), "Error must contain method name, got: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains("count=3"), "Error must mention expected count, got: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains("size=4"), "Error must mention actual size, got: " + ex.getMessage());
+  }
+
+  // -----------------------------------------------------------------------
+  // Lenient export count (strictExportCount=false) — size mismatch logs WARN
+  // -----------------------------------------------------------------------
+
+  private ListAppender<ILoggingEvent> attachLogCapture() {
+    Logger logger = (Logger) LoggerFactory.getLogger(FixedFormatManagerImpl.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    logger.setLevel(Level.WARN);
+    return appender;
+  }
+
+  private void detachLogCapture(ListAppender<ILoggingEvent> appender) {
+    Logger logger = (Logger) LoggerFactory.getLogger(FixedFormatManagerImpl.class);
+    logger.detachAppender(appender);
+  }
+
+  @Test
+  public void testExportArrayShorterThanCountLenientLogsWarn() {
+    LenientRecord record = new LenientRecord();
+    record.setCodes(new String[]{"ab", "cd"}); // 2 elements, count=3
+    record.setAmounts(new Integer[]{1, 2});
+
+    ListAppender<ILoggingEvent> appender = attachLogCapture();
+    String exported;
+    try {
+      exported = manager.export(record);
+    } finally {
+      detachLogCapture(appender);
+    }
+
+    // No exception — available elements are exported
+    assertTrue(exported.startsWith("ab   cd   "), "Available elements should be exported, got: " + exported);
+
+    assertTrue(appender.list.stream()
+        .anyMatch(e -> e.getLevel() == Level.WARN && e.getFormattedMessage().contains("getCodes")),
+        "A WARN log entry mentioning getCodes must be emitted");
+  }
+
+  @Test
+  public void testExportArrayLongerThanCountLenientLogsWarn() {
+    LenientRecord record = new LenientRecord();
+    record.setCodes(new String[]{"ab", "cd", "ef", "gh"}); // 4 elements, count=3
+    record.setAmounts(new Integer[]{1, 2});
+
+    ListAppender<ILoggingEvent> appender = attachLogCapture();
+    String exported;
+    try {
+      exported = manager.export(record);
+    } finally {
+      detachLogCapture(appender);
+    }
+
+    // Only first 3 elements exported
+    assertEquals("ab   ", exported.substring(0, 5));
+    assertEquals("cd   ", exported.substring(5, 10));
+    assertEquals("ef   ", exported.substring(10, 15));
+
+    assertTrue(appender.list.stream()
+        .anyMatch(e -> e.getLevel() == Level.WARN && e.getFormattedMessage().contains("getCodes")),
+        "A WARN log entry mentioning getCodes must be emitted");
+  }
+
+  @Test
+  public void testExportListShorterThanCountLenientLogsWarn() {
+    LenientListRecord record = new LenientListRecord();
+    record.setCodes(Arrays.asList("ab")); // 1 element, count=3
+
+    ListAppender<ILoggingEvent> appender = attachLogCapture();
+    String exported;
+    try {
+      exported = manager.export(record);
+    } finally {
+      detachLogCapture(appender);
+    }
+
+    assertEquals("ab   ", exported.substring(0, 5));
+
+    assertTrue(appender.list.stream()
+        .anyMatch(e -> e.getLevel() == Level.WARN && e.getFormattedMessage().contains("getCodes")),
+        "A WARN log entry mentioning getCodes must be emitted");
+  }
+
+  // =========================================================================
+  // Corner — partial record (record string shorter than last element offset)
+  // =========================================================================
+
+  @Test
+  public void testLoadPartialRecord() {
+    // Only first two code slots provided; third element (positions 11-15) is beyond string length
+    // FixedFormatUtil returns null for out-of-bounds; StringFormatter parses null to null
+    String shortData = "ab   cd   "; // 10 chars
+    RepeatingFieldRecord record = manager.load(RepeatingFieldRecord.class, shortData);
+    assertNotNull(record.getCodes());
+    assertEquals(3, record.getCodes().length);
+    assertEquals("ab", record.getCodes()[0]);
+    assertEquals("cd", record.getCodes()[1]);
+    assertNull(record.getCodes()[2], "Element beyond record length should be null");
+  }
+}

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestRepeatingFieldSupport.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestRepeatingFieldSupport.java
@@ -1,0 +1,273 @@
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.ancientprogramming.fixedformat4j.annotation.Align;
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.Record;
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestRepeatingFieldSupport {
+
+  private final RepeatingFieldSupport support = new RepeatingFieldSupport();
+
+  // =========================================================================
+  // validateCountAnnotation
+  // =========================================================================
+
+  @Test
+  void validateCount_countLessThanOne_throwsFixedFormatException() throws Exception {
+    Method getter = ValidationFixtures.class.getMethod("getNegativeCount");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    assertThrows(FixedFormatException.class, () -> support.validateCount(getter, fieldAnno));
+  }
+
+  @Test
+  void validateCount_countOneOnCollection_throwsFixedFormatException() throws Exception {
+    Method getter = ValidationFixtures.class.getMethod("getCountOneList");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    assertThrows(FixedFormatException.class, () -> support.validateCount(getter, fieldAnno));
+  }
+
+  @Test
+  void validateCount_countGreaterOneOnScalar_throwsFixedFormatException() throws Exception {
+    Method getter = ValidationFixtures.class.getMethod("getCountManyScalar");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    assertThrows(FixedFormatException.class, () -> support.validateCount(getter, fieldAnno));
+  }
+
+  @Test
+  void validateCount_validCountOnCollection_doesNotThrow() throws Exception {
+    Method getter = ValidationFixtures.class.getMethod("getValidList");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    assertDoesNotThrow(() -> support.validateCount(getter, fieldAnno));
+  }
+
+  // =========================================================================
+  // resolveElementType
+  // =========================================================================
+
+  @Test
+  void resolveElementType_array_returnsComponentType() throws Exception {
+    Method getter = RepeatingFieldRecord.class.getMethod("getCodes");
+    assertEquals(String.class, support.resolveElementType(getter));
+  }
+
+  @Test
+  void resolveElementType_parameterizedList_returnsTypeArg() throws Exception {
+    Method getter = RepeatingFieldCollectionRecord.class.getMethod("getCodes");
+    assertEquals(String.class, support.resolveElementType(getter));
+  }
+
+  @Test
+  @SuppressWarnings("rawtypes")
+  void resolveElementType_rawCollection_throwsFixedFormatException() throws Exception {
+    Method getter = ValidationFixtures.class.getMethod("getRawCollection");
+    assertThrows(FixedFormatException.class, () -> support.resolveElementType(getter));
+  }
+
+  // =========================================================================
+  // assembleCollection
+  // =========================================================================
+
+  @Test
+  void assembleCollection_array_returnsCorrectArray() throws Exception {
+    Method getter = RepeatingFieldRecord.class.getMethod("getCodes");
+    Object result = support.assembleCollection(getter, Arrays.asList("a", "b", "c"));
+    assertInstanceOf(String[].class, result);
+    assertArrayEquals(new String[]{"a", "b", "c"}, (String[]) result);
+  }
+
+  @Test
+  void assembleCollection_list_returnsArrayList() throws Exception {
+    Method getter = RepeatingFieldCollectionRecord.class.getMethod("getCodes");
+    Object result = support.assembleCollection(getter, Arrays.asList("a", "b"));
+    assertInstanceOf(List.class, result);
+    assertEquals(Arrays.asList("a", "b"), result);
+  }
+
+  @Test
+  void assembleCollection_linkedList_returnsLinkedList() throws Exception {
+    Method getter = ValidationFixtures.class.getMethod("getLinkedList");
+    Object result = support.assembleCollection(getter, Arrays.asList("x", "y"));
+    assertInstanceOf(LinkedList.class, result);
+  }
+
+  @Test
+  void assembleCollection_sortedSet_returnsTreeSet() throws Exception {
+    Method getter = ValidationFixtures.class.getMethod("getSortedSet");
+    Object result = support.assembleCollection(getter, Arrays.asList("b", "a"));
+    assertInstanceOf(TreeSet.class, result);
+  }
+
+  @Test
+  void assembleCollection_set_returnsLinkedHashSet() throws Exception {
+    Method getter = ValidationFixtures.class.getMethod("getSet");
+    Object result = support.assembleCollection(getter, Arrays.asList("x"));
+    assertInstanceOf(Set.class, result);
+  }
+
+  @Test
+  void assembleCollection_unsupportedType_throwsFixedFormatException() throws Exception {
+    Method getter = ValidationFixtures.class.getMethod("getString");
+    assertThrows(FixedFormatException.class,
+        () -> support.assembleCollection(getter, Arrays.asList("a", "b")));
+  }
+
+  // =========================================================================
+  // read
+  // =========================================================================
+
+  @Test
+  void read_repeatingField_parsesAllElements() throws Exception {
+    Method getter = RepeatingFieldRecord.class.getMethod("getCodes");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    String data = "ab   cd   ef   0004200099";
+
+    Object result = support.read(RepeatingFieldRecord.class, data, getter, getter, fieldAnno);
+
+    assertInstanceOf(String[].class, result);
+    String[] codes = (String[]) result;
+    assertEquals(3, codes.length);
+    assertEquals("ab", codes[0]);
+    assertEquals("cd", codes[1]);
+    assertEquals("ef", codes[2]);
+  }
+
+  // =========================================================================
+  // export
+  // =========================================================================
+
+  @Test
+  void export_repeatingField_writesAllElements() throws Exception {
+    RepeatingFieldRecord record = new RepeatingFieldRecord();
+    record.setCodes(new String[]{"ab", "cd", "ef"});
+    record.setAmounts(new Integer[]{42, 99});
+
+    Method getter = RepeatingFieldRecord.class.getMethod("getCodes");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    AnnotationTarget target = AnnotationTarget.ofMethod(getter);
+    HashMap<Integer, String> foundData = new HashMap<>();
+
+    support.export(record, target, fieldAnno, foundData);
+
+    assertEquals(3, foundData.size());
+    assertEquals("ab   ", foundData.get(1));
+    assertEquals("cd   ", foundData.get(6));
+    assertEquals("ef   ", foundData.get(11));
+  }
+
+  @Test
+  void export_nullCollection_throwsFixedFormatException() throws Exception {
+    RepeatingFieldRecord record = new RepeatingFieldRecord();
+    record.setCodes(null);
+
+    Method getter = RepeatingFieldRecord.class.getMethod("getCodes");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    AnnotationTarget target = AnnotationTarget.ofMethod(getter);
+
+    assertThrows(FixedFormatException.class,
+        () -> support.export(record, target, fieldAnno, new HashMap<>()));
+  }
+
+  @Test
+  void export_sizeMismatch_strictMode_throwsFixedFormatException() throws Exception {
+    RepeatingFieldRecord record = new RepeatingFieldRecord();
+    record.setCodes(new String[]{"ab", "cd"});  // count=3 but only 2 elements
+
+    Method getter = RepeatingFieldRecord.class.getMethod("getCodes");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    AnnotationTarget target = AnnotationTarget.ofMethod(getter);
+
+    assertThrows(FixedFormatException.class,
+        () -> support.export(record, target, fieldAnno, new HashMap<>()));
+  }
+
+  @Test
+  void export_sizeMismatch_nonStrictMode_logsWarnAndExportsMin() throws Exception {
+    Method getter = LenientFixture.class.getMethod("getCodes");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+
+    LenientFixture record = new LenientFixture();
+    record.setCodes(new String[]{"ab", "cd"});  // count=3 but only 2 elements
+
+    AnnotationTarget target = AnnotationTarget.ofMethod(getter);
+    HashMap<Integer, String> foundData = new HashMap<>();
+
+    Logger logger = (Logger) LoggerFactory.getLogger(RepeatingFieldSupport.class);
+    ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    logger.setLevel(Level.WARN);
+    try {
+      support.export(record, target, fieldAnno, foundData);
+    } finally {
+      logger.detachAppender(appender);
+    }
+
+    assertEquals(2, foundData.size());
+    assertTrue(appender.list.stream()
+        .anyMatch(e -> e.getLevel() == Level.WARN && e.getFormattedMessage().contains("getCodes")),
+        "Expected WARN log mentioning getCodes");
+  }
+
+  // =========================================================================
+  // Fixture classes
+  // =========================================================================
+
+  @Record
+  public static class ValidationFixtures {
+    @Field(offset = 1, length = 5, count = -1)
+    public String getNegativeCount() { return null; }
+
+    @Field(offset = 1, length = 5, count = 1)
+    public List<String> getCountOneList() { return null; }
+
+    @Field(offset = 1, length = 5, count = 3)
+    public String getCountManyScalar() { return null; }
+
+    @Field(offset = 1, length = 5, count = 2)
+    public List<String> getValidList() { return null; }
+
+    @Field(offset = 1, length = 5, count = 2)
+    @SuppressWarnings("rawtypes")
+    public Collection getRawCollection() { return null; }
+
+    @Field(offset = 1, length = 5, count = 2)
+    public LinkedList<String> getLinkedList() { return null; }
+
+    @Field(offset = 1, length = 5, count = 2)
+    public SortedSet<String> getSortedSet() { return null; }
+
+    @Field(offset = 1, length = 5, count = 2)
+    public Set<String> getSet() { return null; }
+
+    @Field(offset = 1, length = 5)
+    public String getString() { return null; }
+  }
+
+  @Record
+  public static class LenientFixture {
+    private String[] codes;
+
+    @Field(offset = 1, length = 5, count = 3, strictExportCount = false)
+    public String[] getCodes() { return codes; }
+    public void setCodes(String[] codes) { this.codes = codes; }
+  }
+}

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestRepeatingFieldSupport.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestRepeatingFieldSupport.java
@@ -266,7 +266,7 @@ public class TestRepeatingFieldSupport {
   public static class LenientFixture {
     private String[] codes;
 
-    @Field(offset = 1, length = 5, count = 3, strictExportCount = false)
+    @Field(offset = 1, length = 5, count = 3, strictCount = false)
     public String[] getCodes() { return codes; }
     public void setCodes(String[] codes) { this.codes = codes; }
   }

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestShortFormatter.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestShortFormatter.java
@@ -30,7 +30,7 @@ import static com.ancientprogramming.fixedformat4j.annotation.FixedFormatNumber.
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.3.0
  */
 public class TestShortFormatter {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestStringFormatter.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestStringFormatter.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
 public class TestStringFormatter {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/issues/TestIssue10.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/issues/TestIssue10.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Verifies Issue 10 - parse exception contains details for better error reporting posibilities
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.3.0
  */
 public class TestIssue10 {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/issues/TestIssue7.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/issues/TestIssue7.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Verifies Issue 7 - record contains other fixedformatted records
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.3.0
  */
 public class TestIssue7 {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/issues/TestIssue9.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/issues/TestIssue9.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Verifies Issue 9
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.2.1
  */
 public class TestIssue9 {

--- a/fixedformat4j/src/test/resources/logback-test.xml
+++ b/fixedformat4j/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="WARN">
+    <appender-ref ref="CONSOLE"/>
+  </root>
+</configuration>

--- a/samples/src/main/java/com/ancientprogramming/fixedformat4j/samples/basic/BasicRecord.java
+++ b/samples/src/main/java/com/ancientprogramming/fixedformat4j/samples/basic/BasicRecord.java
@@ -25,7 +25,7 @@ import java.util.Date;
 /**
  * A record containing some simple datatypes to show basic parsing and formatting.
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.2.0
  */
 //START-SNIPPET: basicrecord

--- a/samples/src/main/java/com/ancientprogramming/fixedformat4j/samples/basic/BasicUsage.java
+++ b/samples/src/main/java/com/ancientprogramming/fixedformat4j/samples/basic/BasicUsage.java
@@ -21,7 +21,7 @@ import com.ancientprogramming.fixedformat4j.format.impl.FixedFormatManagerImpl;
 /**
  * Shows the basic usage
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.2.0
  */
 //START-SNIPPET: basicusage

--- a/samples/src/main/java/com/ancientprogramming/fixedformat4j/samples/usage/BasicUsageManager.java
+++ b/samples/src/main/java/com/ancientprogramming/fixedformat4j/samples/usage/BasicUsageManager.java
@@ -22,7 +22,7 @@ import com.ancientprogramming.fixedformat4j.samples.basic.BasicRecord;
 /**
  * Shows the basic usage
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.2.0
  */
 public class BasicUsageManager {

--- a/samples/src/main/java/com/ancientprogramming/fixedformat4j/samples/usage/BasicUsageRecord.java
+++ b/samples/src/main/java/com/ancientprogramming/fixedformat4j/samples/usage/BasicUsageRecord.java
@@ -25,7 +25,7 @@ import java.util.Date;
 /**
  * A record containing some simple datatypes to show basic parsing and formatting.
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.2.0
  */
 //START-SNIPPET: basicusage

--- a/samples/src/main/java/com/ancientprogramming/fixedformat4j/samples/usage/NestedRecord.java
+++ b/samples/src/main/java/com/ancientprogramming/fixedformat4j/samples/usage/NestedRecord.java
@@ -27,7 +27,7 @@ import java.util.Date;
 /**
  * A record containing a simple datatype as well as a nested record annotated datatype.
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.3.0
  */
 //START-SNIPPET: nestedrecord

--- a/samples/src/main/java/com/ancientprogramming/fixedformat4j/samples/usage/NestedRecordUsage.java
+++ b/samples/src/main/java/com/ancientprogramming/fixedformat4j/samples/usage/NestedRecordUsage.java
@@ -22,7 +22,7 @@ import com.ancientprogramming.fixedformat4j.samples.basic.BasicRecord;
 /**
  * Shows how to access nested record data
  *
- * @author Jacob von Eyben - https://eybenconsult.com
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.3.0
  */
 public class NestedRecordUsage {


### PR DESCRIPTION
## Summary

- **Repeating fields** — `@Field(count = N)` maps N consecutive same-format slots in a record to a Java array or ordered `Collection` (`List`, `LinkedList`, `Set`, `SortedSet`, `Collection`). Each slot occupies `length` characters starting at `offset + length * index`.
- **`strictExportCount`** — controls export behaviour on size mismatch: `true` (default) throws `FixedFormatException`; `false` logs a warning and exports `min(count, actualSize)` elements.
- **Internal refactor** — `FixedFormatManagerImpl` split into focused package-private collaborators (`AnnotationScanner`, `AnnotationTarget`, `FormatInstructionsBuilder`, `RecordInstantiator`, `RepeatingFieldSupport`). No public API change.
- **Javadoc** — all public methods across all production classes now have complete javadoc with `@param`/`@return`/`@throws` tags.
- **Documentation** — changelog entry for 1.5.1, Example 7 (repeating fields walkthrough), updated annotation reference, and feature bullet on the home page.

## Test plan

- [ ] `mvn test -pl fixedformat4j` — all tests green
- [ ] `TestRepeatingField` — integration tests covering array and collection round-trips, strict/lenient export, partial records, and validation errors
- [ ] `TestRepeatingFieldSupport` — unit tests for `RepeatingFieldSupport` in isolation
- [ ] `TestAnnotationScanner`, `TestFormatInstructionsBuilder`, `TestRecordInstantiator` — unit tests for the new collaborator classes
- [ ] No breaking API changes confirmed (all new `@Field` elements have defaults; no public signatures changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)