### PR TITLE
Add LocalDateTime support with type-specific default patterns and eager pattern validation

### DIFF
--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/FixedFormatPattern.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/FixedFormatPattern.java
@@ -34,6 +34,10 @@ public @interface FixedFormatPattern {
 
   public static final String DATE_PATTERN = "yyyyMMdd";
 
+  public static final String LOCALDATE_PATTERN = "yyyy-MM-dd";
+
+  public static final String DATETIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss";
+
   /**
    * The pattern used in formatting and parsing a fixed format field.
    * Date: yyyyMMdd

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatPatternData.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatPatternData.java
@@ -16,7 +16,10 @@
 package com.ancientprogramming.fixedformat4j.format.data;
 
 import com.ancientprogramming.fixedformat4j.annotation.FixedFormatPattern;
-import static com.ancientprogramming.fixedformat4j.annotation.FixedFormatPattern.*;
+
+import static com.ancientprogramming.fixedformat4j.annotation.FixedFormatPattern.DATE_PATTERN;
+import static com.ancientprogramming.fixedformat4j.annotation.FixedFormatPattern.LOCALDATE_PATTERN;
+import static com.ancientprogramming.fixedformat4j.annotation.FixedFormatPattern.DATETIME_PATTERN;
 
 /**
  * Data object containing the exact same data as {@link FixedFormatPattern}
@@ -28,6 +31,8 @@ public class FixedFormatPatternData {
 
   private String pattern;
   public static final FixedFormatPatternData DEFAULT = new FixedFormatPatternData(DATE_PATTERN);
+  public static final FixedFormatPatternData LOCALDATE_DEFAULT = new FixedFormatPatternData(LOCALDATE_PATTERN);
+  public static final FixedFormatPatternData DATETIME_DEFAULT = new FixedFormatPatternData(DATETIME_PATTERN);
 
   /**
    * Creates a pattern data object with the given date/time pattern.

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ByTypeFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ByTypeFormatter.java
@@ -23,6 +23,7 @@ import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -30,7 +31,8 @@ import java.util.Map;
 /**
  * Formatter capable of formatting a bunch of known java standard library classes. So far:
  * {@link String}, {@link Integer}, {@link Short}, {@link Long}, {@link Date}, {@link LocalDate},
- * {@link Character}, {@link Boolean}, {@link Double}, {@link Float} and {@link BigDecimal}
+ * {@link java.time.LocalDateTime}, {@link Character}, {@link Boolean}, {@link Double}, {@link Float}
+ * and {@link BigDecimal}
  *
  *
  * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
@@ -51,6 +53,7 @@ public class ByTypeFormatter implements FixedFormatter<Object> {
     KNOWN_FORMATTERS.put(Long.class, LongFormatter.class);
     KNOWN_FORMATTERS.put(Date.class, DateFormatter.class);
     KNOWN_FORMATTERS.put(LocalDate.class, LocalDateFormatter.class);
+    KNOWN_FORMATTERS.put(LocalDateTime.class, LocalDateTimeFormatter.class);
     KNOWN_FORMATTERS.put(char.class, CharacterFormatter.class);
     KNOWN_FORMATTERS.put(Character.class, CharacterFormatter.class);
     KNOWN_FORMATTERS.put(boolean.class, BooleanFormatter.class);

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
@@ -17,6 +17,7 @@ package com.ancientprogramming.fixedformat4j.format.impl;
 
 import com.ancientprogramming.fixedformat4j.annotation.Field;
 import com.ancientprogramming.fixedformat4j.annotation.Fields;
+import com.ancientprogramming.fixedformat4j.annotation.FixedFormatPattern;
 import com.ancientprogramming.fixedformat4j.annotation.Record;
 import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
 import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
@@ -24,6 +25,7 @@ import com.ancientprogramming.fixedformat4j.format.FixedFormatter;
 import com.ancientprogramming.fixedformat4j.format.FormatContext;
 import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
 import com.ancientprogramming.fixedformat4j.format.ParseException;
+import com.ancientprogramming.fixedformat4j.format.data.FixedFormatPatternData;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,8 +33,10 @@ import org.slf4j.LoggerFactory;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.ancientprogramming.fixedformat4j.format.FixedFormatUtil.fetchData;
 import static com.ancientprogramming.fixedformat4j.format.FixedFormatUtil.getFixedFormatterInstance;
@@ -47,6 +51,7 @@ import static java.lang.String.format;
 public class FixedFormatManagerImpl implements FixedFormatManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(FixedFormatManagerImpl.class);
+  private static final Set<Class<?>> VALIDATED_CLASSES = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
   private final AnnotationScanner annotationScanner = new AnnotationScanner();
   private final FormatInstructionsBuilder instructionsBuilder = new FormatInstructionsBuilder();
@@ -60,6 +65,7 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
     HashMap<String, Object> foundData = new HashMap<String, Object>();
     HashMap<String, Class<?>> methodClass = new HashMap<String, Class<?>>();
     getAndAssertRecordAnnotation(fixedFormatRecordClass);
+    validatePatterns(fixedFormatRecordClass);
 
     T instance = recordInstantiator.instantiate(fixedFormatRecordClass);
 
@@ -111,6 +117,7 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
   public <T> String export(String template, T fixedFormatRecord) {
     StringBuffer result = new StringBuffer(template);
     Record record = getAndAssertRecordAnnotation(fixedFormatRecord.getClass());
+    validatePatterns(fixedFormatRecord.getClass());
 
     HashMap<Integer, String> foundData = new HashMap<Integer, String>();
     for (AnnotationTarget target : annotationScanner.scan(fixedFormatRecord.getClass())) {
@@ -148,6 +155,40 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
     return export("", fixedFormatRecord);
   }
 
+  private void validatePatterns(Class<?> recordClass) {
+    if (VALIDATED_CLASSES.contains(recordClass)) {
+      return;
+    }
+    for (AnnotationTarget target : annotationScanner.scan(recordClass)) {
+      Field fieldAnnotation = target.annotationSource.getAnnotation(Field.class);
+      Fields fieldsAnnotation = target.annotationSource.getAnnotation(Fields.class);
+      if (fieldAnnotation != null) {
+        validateFieldPattern(target, fieldAnnotation);
+      } else if (fieldsAnnotation != null) {
+        for (Field field : fieldsAnnotation.value()) {
+          validateFieldPattern(target, field);
+        }
+      }
+    }
+    VALIDATED_CLASSES.add(recordClass);
+  }
+
+  private void validateFieldPattern(AnnotationTarget target, Field fieldAnnotation) {
+    Class<?> datatype = instructionsBuilder.datatype(target.getter, fieldAnnotation);
+    FixedFormatPattern patternAnnotation = target.annotationSource.getAnnotation(FixedFormatPattern.class);
+    String pattern;
+    if (patternAnnotation != null) {
+      pattern = patternAnnotation.value();
+    } else if (java.time.LocalDate.class.equals(datatype)) {
+      pattern = FixedFormatPatternData.LOCALDATE_DEFAULT.getPattern();
+    } else if (java.time.LocalDateTime.class.equals(datatype)) {
+      pattern = FixedFormatPatternData.DATETIME_DEFAULT.getPattern();
+    } else {
+      pattern = FixedFormatPatternData.DEFAULT.getPattern();
+    }
+    PatternValidator.validate(datatype, pattern);
+  }
+
   private void appendData(StringBuffer result, Character paddingChar, Integer offset, String data) {
     int zeroBasedOffset = offset - 1;
     while (result.length() < zeroBasedOffset) {
@@ -180,7 +221,7 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
 
     FormatContext<?> context = instructionsBuilder.context(datatype, fieldAnno);
     FixedFormatter<?> formatter = getFixedFormatterInstance(context.getFormatter(), context);
-    FormatInstructions formatdata = instructionsBuilder.build(annotationSource, fieldAnno);
+    FormatInstructions formatdata = instructionsBuilder.build(annotationSource, fieldAnno, datatype);
 
     String dataToParse = fetchData(data, formatdata, context);
 
@@ -210,7 +251,7 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
 
     FormatContext<?> context = instructionsBuilder.context(datatype, fieldAnno);
     FixedFormatter<?> formatter = getFixedFormatterInstance(context.getFormatter(), context);
-    FormatInstructions formatdata = instructionsBuilder.build(target.annotationSource, fieldAnno);
+    FormatInstructions formatdata = instructionsBuilder.build(target.annotationSource, fieldAnno, datatype);
     Object valueObject;
     try {
       valueObject = target.getter.invoke(fixedFormatRecord);

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FormatInstructionsBuilder.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FormatInstructionsBuilder.java
@@ -16,6 +16,8 @@ import com.ancientprogramming.fixedformat4j.format.data.FixedFormatPatternData;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import static java.lang.String.format;
 
@@ -27,8 +29,8 @@ import static java.lang.String.format;
  */
 class FormatInstructionsBuilder {
 
-  FormatInstructions build(AnnotatedElement annotationSource, Field fieldAnno) {
-    FixedFormatPatternData patternData = patternData(annotationSource.getAnnotation(FixedFormatPattern.class));
+  FormatInstructions build(AnnotatedElement annotationSource, Field fieldAnno, Class<?> datatype) {
+    FixedFormatPatternData patternData = patternData(annotationSource.getAnnotation(FixedFormatPattern.class), datatype);
     FixedFormatBooleanData booleanData = booleanData(annotationSource.getAnnotation(FixedFormatBoolean.class));
     FixedFormatNumberData numberData = numberData(annotationSource.getAnnotation(FixedFormatNumber.class));
     FixedFormatDecimalData decimalData = decimalData(annotationSource.getAnnotation(FixedFormatDecimal.class));
@@ -52,9 +54,15 @@ class FormatInstructionsBuilder {
         method.getName(), fieldAnno.getClass().getName(), fieldAnno.getClass().getName()));
   }
 
-  private FixedFormatPatternData patternData(FixedFormatPattern annotation) {
+  private FixedFormatPatternData patternData(FixedFormatPattern annotation, Class<?> datatype) {
     if (annotation != null) {
       return new FixedFormatPatternData(annotation.value());
+    }
+    if (LocalDate.class.equals(datatype)) {
+      return FixedFormatPatternData.LOCALDATE_DEFAULT;
+    }
+    if (LocalDateTime.class.equals(datatype)) {
+      return FixedFormatPatternData.DATETIME_DEFAULT;
     }
     return FixedFormatPatternData.DEFAULT;
   }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/LocalDateTimeFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/LocalDateTimeFormatter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2004 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+import com.ancientprogramming.fixedformat4j.format.AbstractFixedFormatter;
+import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
+import org.apache.commons.lang3.StringUtils;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Formatter for {@link java.time.LocalDateTime} data.
+ * The formatting and parsing is performed using {@link DateTimeFormatter}.
+ * The pattern is configured via {@link com.ancientprogramming.fixedformat4j.annotation.FixedFormatPattern}.
+ * The default pattern is {@code yyyy-MM-dd'T'HH:mm:ss} (ISO-8601 local date-time).
+ *
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
+ * @since 1.6.0
+ */
+public class LocalDateTimeFormatter extends AbstractFixedFormatter<LocalDateTime> {
+
+  /** {@inheritDoc} */
+  public LocalDateTime asObject(String string, FormatInstructions instructions) throws FixedFormatException {
+    if (StringUtils.isEmpty(string)) {
+      return null;
+    }
+    String pattern = instructions.getFixedFormatPatternData().getPattern();
+    try {
+      return LocalDateTime.parse(string, DateTimeFormatter.ofPattern(pattern));
+    } catch (DateTimeParseException e) {
+      throw new FixedFormatException(String.format("Could not parse value[%s] by pattern[%s] to %s", string, pattern, LocalDateTime.class.getName()));
+    }
+  }
+
+  /** {@inheritDoc} */
+  public String asString(LocalDateTime dateTime, FormatInstructions instructions) {
+    if (dateTime == null) {
+      return null;
+    }
+    String pattern = instructions.getFixedFormatPatternData().getPattern();
+    return DateTimeFormatter.ofPattern(pattern).format(dateTime);
+  }
+}

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/PatternValidator.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/PatternValidator.java
@@ -1,0 +1,56 @@
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+/**
+ * Validates date/time pattern strings for the types supported by this library.
+ *
+ * <p>Validation is performed eagerly — before any data is parsed or formatted — so that
+ * configuration errors surface immediately when a record class is first used, rather than
+ * at the point a specific field is processed.
+ *
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
+ * @since 1.6.0
+ */
+class PatternValidator {
+
+  /**
+   * Validates that {@code pattern} is a legal format pattern for {@code datatype}.
+   *
+   * <p>Validation is performed only for date/time types ({@link Date}, {@link LocalDate},
+   * {@link LocalDateTime}). For all other types the method returns immediately.
+   *
+   * @param datatype the field's Java type
+   * @param pattern  the pattern string from {@link com.ancientprogramming.fixedformat4j.annotation.FixedFormatPattern}
+   * @throws FixedFormatException if the pattern is invalid for the given type
+   */
+  static void validate(Class<?> datatype, String pattern) {
+    if (Date.class.equals(datatype)) {
+      validateSimpleDateFormat(pattern);
+    } else if (LocalDate.class.equals(datatype) || LocalDateTime.class.equals(datatype)) {
+      validateDateTimeFormatter(pattern);
+    }
+  }
+
+  private static void validateSimpleDateFormat(String pattern) {
+    try {
+      new SimpleDateFormat(pattern);
+    } catch (IllegalArgumentException e) {
+      throw new FixedFormatException(String.format("Invalid date pattern '%s': %s", pattern, e.getMessage()), e);
+    }
+  }
+
+  private static void validateDateTimeFormatter(String pattern) {
+    try {
+      DateTimeFormatter.ofPattern(pattern);
+    } catch (IllegalArgumentException e) {
+      throw new FixedFormatException(String.format("Invalid date/time pattern '%s': %s", pattern, e.getMessage()), e);
+    }
+  }
+}

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/RepeatingFieldSupport.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/RepeatingFieldSupport.java
@@ -48,7 +48,7 @@ class RepeatingFieldSupport {
   Object read(Class<?> clazz, String data, Method getter, AnnotatedElement annotationSource, Field fieldAnno) {
     int count = fieldAnno.count();
     Class<?> elementType = resolveElementType(getter);
-    FormatInstructions formatdata = instructionsBuilder.build(annotationSource, fieldAnno);
+    FormatInstructions formatdata = instructionsBuilder.build(annotationSource, fieldAnno, elementType);
 
     FormatContext protoContext = new FormatContext(fieldAnno.offset(), elementType, fieldAnno.formatter());
     FixedFormatter<Object> formatter = (FixedFormatter<Object>) getFixedFormatterInstance(protoContext.getFormatter(), protoContext);
@@ -102,7 +102,7 @@ class RepeatingFieldSupport {
 
     int exportCount = Math.min(count, actualSize);
     Class<?> elementType = resolveElementType(target.getter);
-    FormatInstructions formatdata = instructionsBuilder.build(target.annotationSource, fieldAnno);
+    FormatInstructions formatdata = instructionsBuilder.build(target.annotationSource, fieldAnno, elementType);
     FormatContext protoContext = new FormatContext(fieldAnno.offset(), elementType, fieldAnno.formatter());
     FixedFormatter<Object> formatter = (FixedFormatter<Object>) getFixedFormatterInstance(protoContext.getFormatter(), protoContext);
 

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestByTypeFormatter.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestByTypeFormatter.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.UUID;
 
@@ -164,6 +165,15 @@ public class TestByTypeFormatter {
         new FixedFormatPatternData("yyyyMMdd"), null, null, null);
     assertEquals(LocalDate.of(2026, 4, 5), f.parse("20260405", instr));
     assertEquals("20260405", f.format(LocalDate.of(2026, 4, 5), instr));
+  }
+
+  @Test
+  public void testDispatchesToLocalDateTimeFormatter() {
+    ByTypeFormatter f = formatterFor(LocalDateTime.class);
+    FormatInstructions instr = new FormatInstructions(19, Align.LEFT, ' ',
+        new FixedFormatPatternData("yyyy-MM-dd'T'HH:mm:ss"), null, null, null);
+    assertEquals(LocalDateTime.of(2026, 4, 9, 14, 30, 0), f.parse("2026-04-09T14:30:00", instr));
+    assertEquals("2026-04-09T14:30:00", f.format(LocalDateTime.of(2026, 4, 9, 14, 30, 0), instr));
   }
 
   @Test

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestFixedFormatManagerImpl.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestFixedFormatManagerImpl.java
@@ -28,7 +28,9 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Calendar;
+import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -292,5 +294,151 @@ public class TestFixedFormatManagerImpl {
     @com.ancientprogramming.fixedformat4j.annotation.FixedFormatBoolean(trueValue = "T", falseValue = "F")
     public boolean isActive() { return active; }
     public void setActive(boolean active) { this.active = active; }
+  }
+
+  // --- Default-pattern fallback tests ---
+
+  @Test
+  public void testLocalDateNoPatternAnnotationUsesIsoLocalDateDefault() {
+    LocalDateNoPatternRecord rec = new LocalDateNoPatternRecord();
+    rec.setEventDate(LocalDate.of(2026, 4, 9));
+    String exported = manager.export(rec);
+    assertEquals("2026-04-09", exported);
+
+    LocalDateNoPatternRecord loaded = manager.load(LocalDateNoPatternRecord.class, exported);
+    assertEquals(LocalDate.of(2026, 4, 9), loaded.getEventDate());
+  }
+
+  @Record
+  public static class LocalDateNoPatternRecord {
+    private LocalDate eventDate;
+
+    @Field(offset = 1, length = 10)
+    public LocalDate getEventDate() { return eventDate; }
+    public void setEventDate(LocalDate eventDate) { this.eventDate = eventDate; }
+  }
+
+  // --- LocalDateTime round-trip tests ---
+
+  @Test
+  public void testLocalDateTimeRoundTrip() {
+    LocalDateTimeRecord rec = new LocalDateTimeRecord();
+    rec.setEventAt(LocalDateTime.of(2026, 4, 9, 14, 30, 0));
+    rec.setLabel("launch");
+    String exported = manager.export(rec);
+    assertEquals("launch    2026-04-09T14:30:00", exported);
+
+    LocalDateTimeRecord loaded = manager.load(LocalDateTimeRecord.class, exported);
+    assertEquals("launch", loaded.getLabel());
+    assertEquals(LocalDateTime.of(2026, 4, 9, 14, 30, 0), loaded.getEventAt());
+  }
+
+  @Test
+  public void testLocalDateTimeNoPatternAnnotationUsesIsoDefault() {
+    LocalDateTimeNoPatternRecord rec = new LocalDateTimeNoPatternRecord();
+    rec.setEventAt(LocalDateTime.of(2026, 4, 9, 14, 30, 0));
+    String exported = manager.export(rec);
+    assertEquals("2026-04-09T14:30:00", exported);
+
+    LocalDateTimeNoPatternRecord loaded = manager.load(LocalDateTimeNoPatternRecord.class, exported);
+    assertEquals(LocalDateTime.of(2026, 4, 9, 14, 30, 0), loaded.getEventAt());
+  }
+
+  @Record
+  public static class LocalDateTimeRecord {
+    private String label;
+    private LocalDateTime eventAt;
+
+    @Field(offset = 1, length = 10)
+    public String getLabel() { return label; }
+    public void setLabel(String label) { this.label = label; }
+
+    @Field(offset = 11, length = 19)
+    @FixedFormatPattern("yyyy-MM-dd'T'HH:mm:ss")
+    public LocalDateTime getEventAt() { return eventAt; }
+    public void setEventAt(LocalDateTime eventAt) { this.eventAt = eventAt; }
+  }
+
+  @Record
+  public static class LocalDateTimeNoPatternRecord {
+    private LocalDateTime eventAt;
+
+    @Field(offset = 1, length = 19)
+    public LocalDateTime getEventAt() { return eventAt; }
+    public void setEventAt(LocalDateTime eventAt) { this.eventAt = eventAt; }
+  }
+
+  // --- Pattern validation tests ---
+
+  @Test
+  public void testInvalidDatePatternOnLoadThrowsFixedFormatException() {
+    assertThrows(FixedFormatException.class, () ->
+        manager.load(InvalidDatePatternRecord.class, "20260409")
+    );
+  }
+
+  @Test
+  public void testInvalidDatePatternOnExportThrowsFixedFormatException() {
+    InvalidDatePatternRecord rec = new InvalidDatePatternRecord();
+    rec.setEventDate(new Date());
+    assertThrows(FixedFormatException.class, () -> manager.export(rec));
+  }
+
+  @Test
+  public void testInvalidLocalDatePatternOnLoadThrowsFixedFormatException() {
+    assertThrows(FixedFormatException.class, () ->
+        manager.load(InvalidLocalDatePatternRecord.class, "20260409")
+    );
+  }
+
+  @Test
+  public void testInvalidLocalDatePatternOnExportThrowsFixedFormatException() {
+    InvalidLocalDatePatternRecord rec = new InvalidLocalDatePatternRecord();
+    rec.setEventDate(LocalDate.of(2026, 4, 9));
+    assertThrows(FixedFormatException.class, () -> manager.export(rec));
+  }
+
+  @Test
+  public void testInvalidLocalDateTimePatternOnLoadThrowsFixedFormatException() {
+    assertThrows(FixedFormatException.class, () ->
+        manager.load(InvalidLocalDateTimePatternRecord.class, "2026-04-09T14:30:00")
+    );
+  }
+
+  @Test
+  public void testInvalidLocalDateTimePatternOnExportThrowsFixedFormatException() {
+    InvalidLocalDateTimePatternRecord rec = new InvalidLocalDateTimePatternRecord();
+    rec.setEventDateTime(LocalDateTime.of(2026, 4, 9, 14, 30, 0));
+    assertThrows(FixedFormatException.class, () -> manager.export(rec));
+  }
+
+  @Record
+  public static class InvalidDatePatternRecord {
+    private Date eventDate;
+
+    @Field(offset = 1, length = 8)
+    @FixedFormatPattern("yyyyjj")
+    public Date getEventDate() { return eventDate; }
+    public void setEventDate(Date eventDate) { this.eventDate = eventDate; }
+  }
+
+  @Record
+  public static class InvalidLocalDatePatternRecord {
+    private LocalDate eventDate;
+
+    @Field(offset = 1, length = 8)
+    @FixedFormatPattern("yyyyjj")
+    public LocalDate getEventDate() { return eventDate; }
+    public void setEventDate(LocalDate eventDate) { this.eventDate = eventDate; }
+  }
+
+  @Record
+  public static class InvalidLocalDateTimePatternRecord {
+    private LocalDateTime eventDateTime;
+
+    @Field(offset = 1, length = 19)
+    @FixedFormatPattern("yyyyjj")
+    public LocalDateTime getEventDateTime() { return eventDateTime; }
+    public void setEventDateTime(LocalDateTime eventDateTime) { this.eventDateTime = eventDateTime; }
   }
 }

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestFormatInstructionsBuilder.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestFormatInstructionsBuilder.java
@@ -29,7 +29,7 @@ public class TestFormatInstructionsBuilder {
   void build_defaultAnnotations_returnsDefaultData() throws Exception {
     Method getter = SimpleRecord.class.getMethod("getValue");
     Field fieldAnno = getter.getAnnotation(Field.class);
-    FormatInstructions instructions = builder.build(getter, fieldAnno);
+    FormatInstructions instructions = builder.build(getter, fieldAnno, getter.getReturnType());
     assertSame(FixedFormatPatternData.DEFAULT, instructions.getFixedFormatPatternData());
     assertSame(FixedFormatBooleanData.DEFAULT, instructions.getFixedFormatBooleanData());
     assertSame(FixedFormatNumberData.DEFAULT, instructions.getFixedFormatNumberData());
@@ -40,7 +40,7 @@ public class TestFormatInstructionsBuilder {
   void build_withFixedFormatPattern_capturesPattern() throws Exception {
     Method getter = PatternRecord.class.getMethod("getValue");
     Field fieldAnno = getter.getAnnotation(Field.class);
-    FormatInstructions instructions = builder.build(getter, fieldAnno);
+    FormatInstructions instructions = builder.build(getter, fieldAnno, getter.getReturnType());
     assertEquals("yyyyMMdd", instructions.getFixedFormatPatternData().getPattern());
   }
 
@@ -48,7 +48,7 @@ public class TestFormatInstructionsBuilder {
   void build_withFixedFormatBoolean_capturesTrueFalseValues() throws Exception {
     Method getter = BoolRecord.class.getMethod("getValue");
     Field fieldAnno = getter.getAnnotation(Field.class);
-    FormatInstructions instructions = builder.build(getter, fieldAnno);
+    FormatInstructions instructions = builder.build(getter, fieldAnno, getter.getReturnType());
     assertEquals("Y", instructions.getFixedFormatBooleanData().getTrueValue());
     assertEquals("N", instructions.getFixedFormatBooleanData().getFalseValue());
   }
@@ -57,7 +57,7 @@ public class TestFormatInstructionsBuilder {
   void build_withFixedFormatNumber_capturesSignConfig() throws Exception {
     Method getter = NumberRecord.class.getMethod("getValue");
     Field fieldAnno = getter.getAnnotation(Field.class);
-    FormatInstructions instructions = builder.build(getter, fieldAnno);
+    FormatInstructions instructions = builder.build(getter, fieldAnno, getter.getReturnType());
     assertEquals(Sign.PREPEND, instructions.getFixedFormatNumberData().getSigning());
   }
 
@@ -65,7 +65,7 @@ public class TestFormatInstructionsBuilder {
   void build_withFixedFormatDecimal_capturesDecimals() throws Exception {
     Method getter = DecimalRecord.class.getMethod("getValue");
     Field fieldAnno = getter.getAnnotation(Field.class);
-    FormatInstructions instructions = builder.build(getter, fieldAnno);
+    FormatInstructions instructions = builder.build(getter, fieldAnno, getter.getReturnType());
     assertEquals(2, instructions.getFixedFormatDecimalData().getDecimals());
   }
 

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestLocalDateTimeFormatter.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestLocalDateTimeFormatter.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2004 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.annotation.Align;
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+import com.ancientprogramming.fixedformat4j.format.FixedFormatter;
+import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
+import com.ancientprogramming.fixedformat4j.format.data.FixedFormatPatternData;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link LocalDateTimeFormatter}.
+ *
+ * @since 1.6.0
+ */
+public class TestLocalDateTimeFormatter {
+
+  private final FixedFormatter<LocalDateTime> formatter = new LocalDateTimeFormatter();
+
+  private FormatInstructions instructions(int length, String pattern) {
+    return new FormatInstructions(length, Align.LEFT, ' ', new FixedFormatPatternData(pattern), null, null, null);
+  }
+
+  // --- Sunshine scenarios ---
+
+  @Test
+  public void testParseIsoPattern() {
+    LocalDateTime result = (LocalDateTime) formatter.parse("2026-04-09T14:30:00", instructions(19, "yyyy-MM-dd'T'HH:mm:ss"));
+    assertEquals(LocalDateTime.of(2026, 4, 9, 14, 30, 0), result);
+  }
+
+  @Test
+  public void testFormatIsoPattern() {
+    assertEquals("2026-04-09T14:30:00", formatter.format(LocalDateTime.of(2026, 4, 9, 14, 30, 0), instructions(19, "yyyy-MM-dd'T'HH:mm:ss")));
+  }
+
+  @Test
+  public void testParseCompactPattern() {
+    LocalDateTime result = (LocalDateTime) formatter.parse("20260409143000", instructions(14, "yyyyMMddHHmmss"));
+    assertEquals(LocalDateTime.of(2026, 4, 9, 14, 30, 0), result);
+  }
+
+  @Test
+  public void testFormatCompactPattern() {
+    assertEquals("20260409143000", formatter.format(LocalDateTime.of(2026, 4, 9, 14, 30, 0), instructions(14, "yyyyMMddHHmmss")));
+  }
+
+  @Test
+  public void testRoundTrip() {
+    LocalDateTime original = LocalDateTime.of(2026, 4, 9, 14, 30, 45);
+    String formatted = formatter.format(original, instructions(19, "yyyy-MM-dd'T'HH:mm:ss"));
+    LocalDateTime parsed = (LocalDateTime) formatter.parse(formatted, instructions(19, "yyyy-MM-dd'T'HH:mm:ss"));
+    assertEquals(original, parsed);
+  }
+
+  @Test
+  public void testMidnight() {
+    LocalDateTime result = (LocalDateTime) formatter.parse("2026-01-01T00:00:00", instructions(19, "yyyy-MM-dd'T'HH:mm:ss"));
+    assertEquals(LocalDateTime.of(2026, 1, 1, 0, 0, 0), result);
+  }
+
+  @Test
+  public void testEndOfDay() {
+    LocalDateTime result = (LocalDateTime) formatter.parse("2026-12-31T23:59:59", instructions(19, "yyyy-MM-dd'T'HH:mm:ss"));
+    assertEquals(LocalDateTime.of(2026, 12, 31, 23, 59, 59), result);
+  }
+
+  @Test
+  public void testLeapDayDateTime() {
+    LocalDateTime result = (LocalDateTime) formatter.parse("2000-02-29T12:00:00", instructions(19, "yyyy-MM-dd'T'HH:mm:ss"));
+    assertEquals(LocalDateTime.of(2000, 2, 29, 12, 0, 0), result);
+  }
+
+  @Test
+  public void testFormatWithSpaceSeparator() {
+    LocalDateTime dt = LocalDateTime.of(2026, 4, 9, 8, 5, 3);
+    assertEquals("2026-04-09 08:05:03", formatter.format(dt, instructions(19, "yyyy-MM-dd HH:mm:ss")));
+  }
+
+  @Test
+  public void testParseWithSpaceSeparator() {
+    FormatInstructions instr = new FormatInstructions(19, Align.LEFT, ' ', new FixedFormatPatternData("yyyy-MM-dd HH:mm:ss"), null, null, null);
+    LocalDateTime result = (LocalDateTime) formatter.parse("2026-04-09 08:05:03", instr);
+    assertEquals(LocalDateTime.of(2026, 4, 9, 8, 5, 3), result);
+  }
+
+  // --- Edge cases ---
+
+  @Test
+  public void testNullFormatReturnsSpaces() {
+    assertEquals("                   ", formatter.format(null, instructions(19, "yyyy-MM-dd'T'HH:mm:ss")));
+  }
+
+  @Test
+  public void testAllSpaceInputParsesToNull() {
+    assertNull(formatter.parse("                   ", instructions(19, "yyyy-MM-dd'T'HH:mm:ss")));
+  }
+
+  @Test
+  public void testRightAlignedPaddingStrippedBeforeParse() {
+    FormatInstructions instr = new FormatInstructions(21, Align.RIGHT, ' ', new FixedFormatPatternData("yyyy-MM-dd'T'HH:mm:ss"), null, null, null);
+    LocalDateTime result = (LocalDateTime) formatter.parse("  2026-04-09T14:30:00", instr);
+    assertEquals(LocalDateTime.of(2026, 4, 9, 14, 30, 0), result);
+  }
+
+  @Test
+  public void testInvalidDateStringThrowsFixedFormatException() {
+    assertThrows(FixedFormatException.class, () ->
+        formatter.parse("9999-99-99T99:99:99", instructions(19, "yyyy-MM-dd'T'HH:mm:ss"))
+    );
+  }
+
+  @Test
+  public void testInvalidMonthThrowsFixedFormatException() {
+    assertThrows(FixedFormatException.class, () ->
+        formatter.parse("2026-13-01T00:00:00", instructions(19, "yyyy-MM-dd'T'HH:mm:ss"))
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Add `LocalDateTimeFormatter` for `java.time.LocalDateTime` fields, dispatched via `ByTypeFormatter`
- Add `PatternValidator` with **class-level eager validation**: all date/time patterns on a record class are validated on first `load()`/`export()` call, surfacing invalid patterns immediately rather than at parse time
- Introduce type-specific default patterns when `@FixedFormatPattern` is absent:
  - `java.util.Date` → `yyyyMMdd`
  - `java.time.LocalDate` → `yyyy-MM-dd`
  - `java.time.LocalDateTime` → `yyyy-MM-dd'T'HH:mm:ss`
- All three types now work with `@Field` alone — `@FixedFormatPattern` remains optional

Closes #68

## Test plan

- [ ] `mvn test` passes (239 tests)
- [ ] `TestLocalDateTimeFormatter` — 14 tests: null/blank, parse/format, round-trip, boundary dates (midnight, end-of-day, leap day), custom patterns, invalid date strings
- [ ] `TestByTypeFormatter` — LocalDateTime dispatch (parse + format)
- [ ] `TestFixedFormatManagerImpl` — invalid pattern on Date/LocalDate/LocalDateTime throws `FixedFormatException` on `load()` and `export()`; LocalDate/LocalDateTime no-annotation default pattern round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)