### PR TITLE
Add PIT mutation testing with GitHub Pages report

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -7,12 +7,17 @@ on:
     - cron: '0 2 * * *'   # 02:00 UTC every day
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 11
         uses: actions/setup-java@v5
@@ -22,3 +27,25 @@ jobs:
 
       - name: Build and test with Maven
         run: mvn -B verify
+
+      - name: Run mutation tests
+        run: mvn -B -pl fixedformat4j pitest:mutationCoverage
+
+      - name: Publish PIT report to docs (master only)
+        if: github.ref == 'refs/heads/master'
+        run: |
+          TOTAL=$(grep -c '<mutation ' fixedformat4j/target/pit-reports/mutations.xml || echo 0)
+          KILLED=$(grep -c 'status="KILLED"' fixedformat4j/target/pit-reports/mutations.xml || echo 0)
+          if [ "$TOTAL" -gt 0 ]; then
+            SCORE=$(( KILLED * 100 / TOTAL ))
+          else
+            SCORE=0
+          fi
+          mkdir -p docs/pit-reports
+          cp -r fixedformat4j/target/pit-reports/. docs/pit-reports/
+          echo "{\"score\":\"${SCORE}%\"}" > docs/mutation-score.json
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/pit-reports/ docs/mutation-score.json
+          git diff --staged --quiet || git commit -m "chore: update PIT mutation report [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Nightly Build](https://github.com/jeyben/fixedformat4j/actions/workflows/nightly-build.yml/badge.svg?branch=master)](https://github.com/jeyben/fixedformat4j/actions/workflows/nightly-build.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/com.ancientprogramming.fixedformat4j/fixedformat4j)](https://central.sonatype.com/artifact/com.ancientprogramming.fixedformat4j/fixedformat4j)
+[![Mutation Score](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fjeyben.github.io%2Ffixedformat4j%2Fmutation-score.json&query=%24.score&label=Mutation%20Score&color=brightgreen)](https://jeyben.github.io/fixedformat4j/pit-reports/)
 
 A small, non-intrusive Java library for reading and writing fixed-width flat-file records using annotations.
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ Full documentation is available at **https://jeyben.github.io/fixedformat4j/**:
 - [FAQ](https://jeyben.github.io/fixedformat4j/faq)
 - [Changelog](https://jeyben.github.io/fixedformat4j/changelog)
 
+**Reports:**
+- [Mutation Report](https://jeyben.github.io/fixedformat4j/pit-reports/) — latest PIT mutation testing results (updated nightly)
+
 ## License
 
 Apache License 2.0 — see [LICENSE](LICENSE) for details.

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -17,3 +17,7 @@
   url: /faq
 - title: Changelog
   url: /changelog
+- title: Reports
+  children:
+    - title: Mutation Report
+      url: /pit-reports/

--- a/fixedformat4j/pom.xml
+++ b/fixedformat4j/pom.xml
@@ -116,6 +116,31 @@
         <version>3.2.5</version>
       </plugin>
       <plugin>
+        <groupId>org.pitest</groupId>
+        <artifactId>pitest-maven</artifactId>
+        <version>1.17.1</version>
+        <configuration>
+          <targetClasses>
+            <param>com.ancientprogramming.fixedformat4j.*</param>
+          </targetClasses>
+          <targetTests>
+            <param>com.ancientprogramming.fixedformat4j.*</param>
+          </targetTests>
+          <outputFormats>
+            <outputFormat>HTML</outputFormat>
+            <outputFormat>XML</outputFormat>
+          </outputFormats>
+          <timestampedReports>false</timestampedReports>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-junit5-plugin</artifactId>
+            <version>1.2.1</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.13.0</version>


### PR DESCRIPTION
## Summary

- Adds `pitest-maven` 1.17.1 (with `pitest-junit5-plugin` 1.2.1 for JUnit 5 support) to `fixedformat4j/pom.xml`
- Nightly build now runs mutation tests after the regular build; on `master` it commits the HTML report to `docs/pit-reports/` and writes `docs/mutation-score.json` for the badge
- README gains a Shields.io dynamic mutation score badge linking to `https://jeyben.github.io/fixedformat4j/pit-reports/`

## Test plan

- [ ] Merge to `master` and verify the nightly build runs PIT without failure
- [ ] Confirm `docs/pit-reports/` is committed back to `master` by `github-actions[bot]`
- [ ] Confirm the pages workflow deploys the report and it is browsable at `https://jeyben.github.io/fixedformat4j/pit-reports/`
- [ ] Confirm the README mutation score badge renders with a percentage

Local run: 309 mutations generated, 90% killed, 91% test strength.

🤖 Generated with [Claude Code](https://claude.com/claude-code)