### PR TITLE
feat: add enum support with correct non-space paddingChar handling (Issue #67)

### DIFF
--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/EnumFormat.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/EnumFormat.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2004 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ancientprogramming.fixedformat4j.annotation;
+
+/**
+ * Defines how an enum field is serialized to/from a fixed-width string.
+ *
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
+ * @since 1.7.0
+ */
+public enum EnumFormat {
+
+  /**
+   * Serializes using {@link Enum#name()} and deserializes using {@link Enum#valueOf(Class, String)}.
+   * This is the default when no {@code @FixedFormatEnum} annotation is present.
+   */
+  LITERAL,
+
+  /**
+   * Serializes using {@link Enum#ordinal()} and deserializes by index lookup into
+   * {@link Class#getEnumConstants()}.
+   */
+  NUMERIC
+}

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/FixedFormatEnum.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/FixedFormatEnum.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2004 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ancientprogramming.fixedformat4j.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Supplementary annotation for enum fields that controls whether the enum is serialized as its
+ * name ({@link EnumFormat#LITERAL}) or its ordinal ({@link EnumFormat#NUMERIC}).
+ *
+ * <p>When omitted, enum fields default to {@link EnumFormat#LITERAL}.
+ *
+ * <p>Example:
+ * <pre>
+ *   &#64;Field(offset = 1, length = 10)
+ *   &#64;FixedFormatEnum(EnumFormat.NUMERIC)
+ *   public Status getStatus() { ... }
+ * </pre>
+ *
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
+ * @since 1.7.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD})
+public @interface FixedFormatEnum {
+
+  /**
+   * The serialization format. Defaults to {@link EnumFormat#LITERAL}.
+   *
+   * @return the enum format to use for this field
+   */
+  EnumFormat value() default EnumFormat.LITERAL;
+}

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FormatInstructions.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FormatInstructions.java
@@ -17,9 +17,10 @@ package com.ancientprogramming.fixedformat4j.format;
 
 import com.ancientprogramming.fixedformat4j.annotation.Align;
 import com.ancientprogramming.fixedformat4j.format.data.FixedFormatBooleanData;
-import com.ancientprogramming.fixedformat4j.format.data.FixedFormatPatternData;
 import com.ancientprogramming.fixedformat4j.format.data.FixedFormatDecimalData;
+import com.ancientprogramming.fixedformat4j.format.data.FixedFormatEnumData;
 import com.ancientprogramming.fixedformat4j.format.data.FixedFormatNumberData;
+import com.ancientprogramming.fixedformat4j.format.data.FixedFormatPatternData;
 
 /**
  * Contains instructions on how to export and load fixed formatted data.
@@ -36,6 +37,23 @@ public class FormatInstructions {
   private FixedFormatBooleanData fixedFormatBooleanData;
   private FixedFormatNumberData fixedFormatNumberData;
   private FixedFormatDecimalData fixedFormatDecimalData;
+  private FixedFormatEnumData fixedFormatEnumData;
+
+  /**
+   * Creates a fully-populated set of format instructions (backward-compatible overload).
+   * Enum data defaults to {@link FixedFormatEnumData#DEFAULT}.
+   *
+   * @param length                  the fixed width of the field in characters
+   * @param alignment               the alignment strategy used to pad and strip the field
+   * @param paddingChar             the character used for padding
+   * @param fixedFormatPatternData  date/time pattern configuration, or {@code null} if unused
+   * @param fixedFormatBooleanData  boolean value configuration, or {@code null} if unused
+   * @param fixedFormatNumberData   number sign configuration, or {@code null} if unused
+   * @param fixedFormatDecimalData  decimal precision configuration, or {@code null} if unused
+   */
+  public FormatInstructions(int length, Align alignment, char paddingChar, FixedFormatPatternData fixedFormatPatternData, FixedFormatBooleanData fixedFormatBooleanData, FixedFormatNumberData fixedFormatNumberData, FixedFormatDecimalData fixedFormatDecimalData) {
+    this(length, alignment, paddingChar, fixedFormatPatternData, fixedFormatBooleanData, fixedFormatNumberData, fixedFormatDecimalData, FixedFormatEnumData.DEFAULT);
+  }
 
   /**
    * Creates a fully-populated set of format instructions.
@@ -47,8 +65,9 @@ public class FormatInstructions {
    * @param fixedFormatBooleanData  boolean value configuration, or {@code null} if unused
    * @param fixedFormatNumberData   number sign configuration, or {@code null} if unused
    * @param fixedFormatDecimalData  decimal precision configuration, or {@code null} if unused
+   * @param fixedFormatEnumData     enum format configuration, or {@code null} to use default
    */
-  public FormatInstructions(int length, Align alignment, char paddingChar, FixedFormatPatternData fixedFormatPatternData, FixedFormatBooleanData fixedFormatBooleanData, FixedFormatNumberData fixedFormatNumberData, FixedFormatDecimalData fixedFormatDecimalData) {
+  public FormatInstructions(int length, Align alignment, char paddingChar, FixedFormatPatternData fixedFormatPatternData, FixedFormatBooleanData fixedFormatBooleanData, FixedFormatNumberData fixedFormatNumberData, FixedFormatDecimalData fixedFormatDecimalData, FixedFormatEnumData fixedFormatEnumData) {
     this.length = length;
     this.alignment = alignment;
     this.paddingChar = paddingChar;
@@ -56,6 +75,7 @@ public class FormatInstructions {
     this.fixedFormatBooleanData = fixedFormatBooleanData;
     this.fixedFormatNumberData = fixedFormatNumberData;
     this.fixedFormatDecimalData = fixedFormatDecimalData;
+    this.fixedFormatEnumData = fixedFormatEnumData;
   }
 
   /**
@@ -121,8 +141,17 @@ public class FormatInstructions {
     return fixedFormatNumberData;
   }
 
+  /**
+   * Returns the enum format configuration for this field.
+   *
+   * @return the {@link FixedFormatEnumData}; never {@code null}
+   */
+  public FixedFormatEnumData getFixedFormatEnumData() {
+    return fixedFormatEnumData;
+  }
+
   public String toString() {
-    return String.format("FormatInstructions{length=%d, alignment=%s, paddingChar='%c', fixedFormatPatternData=%s, fixedFormatBooleanData=%s, fixedFormatNumberData=%s, fixedFormatDecimalData=%s}",
-        length, alignment, paddingChar, fixedFormatPatternData, fixedFormatBooleanData, fixedFormatNumberData, fixedFormatDecimalData);
+    return String.format("FormatInstructions{length=%d, alignment=%s, paddingChar='%c', fixedFormatPatternData=%s, fixedFormatBooleanData=%s, fixedFormatNumberData=%s, fixedFormatDecimalData=%s, fixedFormatEnumData=%s}",
+        length, alignment, paddingChar, fixedFormatPatternData, fixedFormatBooleanData, fixedFormatNumberData, fixedFormatDecimalData, fixedFormatEnumData);
   }
 }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatEnumData.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/data/FixedFormatEnumData.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2004 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ancientprogramming.fixedformat4j.format.data;
+
+import com.ancientprogramming.fixedformat4j.annotation.EnumFormat;
+
+/**
+ * Immutable data object mirroring the {@code @FixedFormatEnum} annotation values.
+ *
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
+ * @since 1.7.0
+ */
+public class FixedFormatEnumData {
+
+  public static final FixedFormatEnumData DEFAULT = new FixedFormatEnumData(EnumFormat.LITERAL);
+
+  private final EnumFormat enumFormat;
+
+  /**
+   * Creates an enum data holder with the given format mode.
+   *
+   * @param enumFormat the serialization format for the enum field
+   */
+  public FixedFormatEnumData(EnumFormat enumFormat) {
+    this.enumFormat = enumFormat;
+  }
+
+  /**
+   * Returns the serialization format.
+   *
+   * @return the {@link EnumFormat} for this field
+   */
+  public EnumFormat getEnumFormat() {
+    return enumFormat;
+  }
+
+  public String toString() {
+    return String.format("FixedFormatEnumData{enumFormat=%s}", enumFormat);
+  }
+}

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ByTypeFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ByTypeFormatter.java
@@ -91,6 +91,7 @@ public class ByTypeFormatter implements FixedFormatter<Object> {
 
   /**
    * Looks up and instantiates the typed formatter for the given {@code dataType}.
+   * Enum types are detected dynamically and routed to {@link EnumFormatter}.
    *
    * @param dataType the Java type of the field value
    * @return a formatter capable of handling {@code dataType}
@@ -98,6 +99,10 @@ public class ByTypeFormatter implements FixedFormatter<Object> {
    *         registered for {@code dataType} or the formatter cannot be instantiated
    */
   public FixedFormatter<?> actualFormatter(final Class<?> dataType) {
+    if (dataType != null && dataType.isEnum()) {
+      return new EnumFormatter(context);
+    }
+
     Class<? extends FixedFormatter<?>> formatterClass = KNOWN_FORMATTERS.get(dataType);
 
     if (formatterClass != null) {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/EnumFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/EnumFormatter.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2004 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.annotation.EnumFormat;
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+import com.ancientprogramming.fixedformat4j.format.AbstractFixedFormatter;
+import com.ancientprogramming.fixedformat4j.format.FormatContext;
+import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
+import com.ancientprogramming.fixedformat4j.format.data.FixedFormatEnumData;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Formatter for Java enum types.
+ *
+ * <p>Supports two serialization modes controlled by {@code @FixedFormatEnum}:
+ * <ul>
+ *   <li>{@link EnumFormat#LITERAL} (default) — uses {@link Enum#name()} / {@link Enum#valueOf}</li>
+ *   <li>{@link EnumFormat#NUMERIC} — uses {@link Enum#ordinal()} / index lookup</li>
+ * </ul>
+ *
+ * <p>Padding is handled by the {@link AbstractFixedFormatter} base class using the field's
+ * configured {@code paddingChar} and {@code align}. This formatter receives a padding-stripped
+ * value in {@link #asObject} and must not apply additional whitespace-specific trimming,
+ * so non-space padding characters (e.g. {@code '*'}, {@code '0'}) are handled correctly.
+ *
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
+ * @since 1.7.0
+ */
+public class EnumFormatter extends AbstractFixedFormatter<Enum> {
+
+  private final FormatContext<?> context;
+
+  /**
+   * Creates an {@code EnumFormatter} bound to the given format context.
+   * The context's data type must be an enum class.
+   *
+   * @param context the format context describing the field's data type
+   */
+  public EnumFormatter(FormatContext<?> context) {
+    this.context = context;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The {@code value} received here has already had its padding stripped by
+   * {@link AbstractFixedFormatter#parse} using the field's actual {@code paddingChar},
+   * so no additional trimming is performed.
+   */
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  @Override
+  public Enum asObject(String value, FormatInstructions instructions) {
+    if (StringUtils.isEmpty(value)) {
+      return null;
+    }
+    Class<? extends Enum> enumClass = (Class<? extends Enum>) context.getDataType();
+    EnumFormat format = enumFormat(instructions);
+    if (format == EnumFormat.NUMERIC) {
+      int ordinal;
+      try {
+        ordinal = Integer.parseInt(value);
+      } catch (NumberFormatException e) {
+        throw new FixedFormatException(
+            String.format("Cannot parse ordinal for enum [%s] from value [%s]", enumClass.getName(), value), e);
+      }
+      Enum<?>[] constants = enumClass.getEnumConstants();
+      if (ordinal < 0 || ordinal >= constants.length) {
+        throw new FixedFormatException(
+            String.format("Ordinal [%d] is out of range for enum [%s] with %d constants", ordinal, enumClass.getName(), constants.length));
+      }
+      return constants[ordinal];
+    } else {
+      try {
+        return Enum.valueOf(enumClass, value);
+      } catch (IllegalArgumentException e) {
+        throw new FixedFormatException(
+            String.format("Cannot find enum constant [%s] in [%s]", value, enumClass.getName()), e);
+      }
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String asString(Enum value, FormatInstructions instructions) {
+    if (value == null) {
+      return null;
+    }
+    return enumFormat(instructions) == EnumFormat.NUMERIC
+        ? String.valueOf(value.ordinal())
+        : value.name();
+  }
+
+  private EnumFormat enumFormat(FormatInstructions instructions) {
+    FixedFormatEnumData data = instructions.getFixedFormatEnumData();
+    return (data != null) ? data.getEnumFormat() : EnumFormat.LITERAL;
+  }
+}

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
@@ -15,8 +15,10 @@
  */
 package com.ancientprogramming.fixedformat4j.format.impl;
 
+import com.ancientprogramming.fixedformat4j.annotation.EnumFormat;
 import com.ancientprogramming.fixedformat4j.annotation.Field;
 import com.ancientprogramming.fixedformat4j.annotation.Fields;
+import com.ancientprogramming.fixedformat4j.annotation.FixedFormatEnum;
 import com.ancientprogramming.fixedformat4j.annotation.FixedFormatPattern;
 import com.ancientprogramming.fixedformat4j.annotation.Record;
 import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
@@ -33,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Set;
@@ -164,13 +167,43 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
       Fields fieldsAnnotation = target.annotationSource.getAnnotation(Fields.class);
       if (fieldAnnotation != null) {
         validateFieldPattern(target, fieldAnnotation);
+        validateEnumFieldLength(target, fieldAnnotation);
       } else if (fieldsAnnotation != null) {
         for (Field field : fieldsAnnotation.value()) {
           validateFieldPattern(target, field);
+          validateEnumFieldLength(target, field);
         }
       }
     }
     VALIDATED_CLASSES.add(recordClass);
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private void validateEnumFieldLength(AnnotationTarget target, Field fieldAnnotation) {
+    Class<?> datatype = instructionsBuilder.datatype(target.getter, fieldAnnotation);
+    if (!datatype.isEnum()) {
+      return;
+    }
+    Enum<?>[] constants = (Enum<?>[]) datatype.getEnumConstants();
+    if (constants == null || constants.length == 0) {
+      return;
+    }
+    FixedFormatEnum enumAnnotation = target.annotationSource.getAnnotation(FixedFormatEnum.class);
+    EnumFormat enumFormat = (enumAnnotation != null) ? enumAnnotation.value() : EnumFormat.LITERAL;
+    int maxLength;
+    if (enumFormat == EnumFormat.NUMERIC) {
+      maxLength = String.valueOf(constants.length - 1).length();
+    } else {
+      maxLength = Arrays.stream(constants)
+          .mapToInt(e -> e.name().length())
+          .max()
+          .orElse(0);
+    }
+    if (maxLength > fieldAnnotation.length()) {
+      throw new FixedFormatException(format(
+          "Enum [%s] has values with max length %d which exceeds @Field length %d",
+          datatype.getName(), maxLength, fieldAnnotation.length()));
+    }
   }
 
   private void validateFieldPattern(AnnotationTarget target, Field fieldAnnotation) {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FormatInstructionsBuilder.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FormatInstructionsBuilder.java
@@ -3,6 +3,7 @@ package com.ancientprogramming.fixedformat4j.format.impl;
 import com.ancientprogramming.fixedformat4j.annotation.Field;
 import com.ancientprogramming.fixedformat4j.annotation.FixedFormatBoolean;
 import com.ancientprogramming.fixedformat4j.annotation.FixedFormatDecimal;
+import com.ancientprogramming.fixedformat4j.annotation.FixedFormatEnum;
 import com.ancientprogramming.fixedformat4j.annotation.FixedFormatNumber;
 import com.ancientprogramming.fixedformat4j.annotation.FixedFormatPattern;
 import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
@@ -10,6 +11,7 @@ import com.ancientprogramming.fixedformat4j.format.FormatContext;
 import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
 import com.ancientprogramming.fixedformat4j.format.data.FixedFormatBooleanData;
 import com.ancientprogramming.fixedformat4j.format.data.FixedFormatDecimalData;
+import com.ancientprogramming.fixedformat4j.format.data.FixedFormatEnumData;
 import com.ancientprogramming.fixedformat4j.format.data.FixedFormatNumberData;
 import com.ancientprogramming.fixedformat4j.format.data.FixedFormatPatternData;
 
@@ -34,7 +36,8 @@ class FormatInstructionsBuilder {
     FixedFormatBooleanData booleanData = booleanData(annotationSource.getAnnotation(FixedFormatBoolean.class));
     FixedFormatNumberData numberData = numberData(annotationSource.getAnnotation(FixedFormatNumber.class));
     FixedFormatDecimalData decimalData = decimalData(annotationSource.getAnnotation(FixedFormatDecimal.class));
-    return new FormatInstructions(fieldAnno.length(), fieldAnno.align(), fieldAnno.paddingChar(), patternData, booleanData, numberData, decimalData);
+    FixedFormatEnumData enumData = enumData(annotationSource.getAnnotation(FixedFormatEnum.class));
+    return new FormatInstructions(fieldAnno.length(), fieldAnno.align(), fieldAnno.paddingChar(), patternData, booleanData, numberData, decimalData, enumData);
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})
@@ -86,5 +89,12 @@ class FormatInstructionsBuilder {
       return new FixedFormatDecimalData(annotation.decimals(), annotation.useDecimalDelimiter(), annotation.decimalDelimiter(), RoundingMode.valueOf(annotation.roundingMode()));
     }
     return FixedFormatDecimalData.DEFAULT;
+  }
+
+  private FixedFormatEnumData enumData(FixedFormatEnum annotation) {
+    if (annotation != null) {
+      return new FixedFormatEnumData(annotation.value());
+    }
+    return FixedFormatEnumData.DEFAULT;
   }
 }

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/issues/TestIssue67EnumSupport.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/issues/TestIssue67EnumSupport.java
@@ -1,0 +1,357 @@
+/*
+ * Copyright 2004 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ancientprogramming.fixedformat4j.issues;
+
+import com.ancientprogramming.fixedformat4j.annotation.Align;
+import com.ancientprogramming.fixedformat4j.annotation.EnumFormat;
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.FixedFormatEnum;
+import com.ancientprogramming.fixedformat4j.annotation.Record;
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
+import com.ancientprogramming.fixedformat4j.format.impl.FixedFormatManagerImpl;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for Issue 67 — enum support in fixed-format records.
+ *
+ * <p>Includes tests for non-space padding characters to verify that
+ * {@code EnumFormatter} relies on the base-class {@code stripPadding()} mechanism
+ * (which uses the field's actual {@code paddingChar}) rather than calling
+ * {@code String.trim()} (which only strips spaces).
+ */
+public class TestIssue67EnumSupport {
+
+  enum Status { ACTIVE, INACTIVE, PENDING }
+
+  enum Priority { LOW, MEDIUM, HIGH }
+
+  // -------------------------------------------------------------------------
+  // Record: LITERAL default (no annotation), space padding (default)
+  // -------------------------------------------------------------------------
+
+  @Record(length = 20)
+  public static class LiteralDefaultRecord {
+    private Status status;
+
+    @Field(offset = 1, length = 10)
+    public Status getStatus() { return status; }
+    public void setStatus(Status status) { this.status = status; }
+  }
+
+  // -------------------------------------------------------------------------
+  // Record: LITERAL explicit annotation, space padding
+  // -------------------------------------------------------------------------
+
+  @Record(length = 20)
+  public static class LiteralExplicitRecord {
+    private Status status;
+
+    @Field(offset = 1, length = 10)
+    @FixedFormatEnum(EnumFormat.LITERAL)
+    public Status getStatus() { return status; }
+    public void setStatus(Status status) { this.status = status; }
+  }
+
+  // -------------------------------------------------------------------------
+  // Record: NUMERIC, space padding
+  // -------------------------------------------------------------------------
+
+  @Record(length = 20)
+  public static class NumericRecord {
+    private Status status;
+
+    @Field(offset = 1, length = 2)
+    @FixedFormatEnum(EnumFormat.NUMERIC)
+    public Status getStatus() { return status; }
+    public void setStatus(Status status) { this.status = status; }
+  }
+
+  // -------------------------------------------------------------------------
+  // Record: LITERAL, non-space paddingChar '*', LEFT-aligned (padding on right)
+  // -------------------------------------------------------------------------
+
+  @Record(length = 20)
+  public static class StarPaddingLeftAlignRecord {
+    private Status status;
+
+    @Field(offset = 1, length = 10, paddingChar = '*', align = Align.LEFT)
+    public Status getStatus() { return status; }
+    public void setStatus(Status status) { this.status = status; }
+  }
+
+  // -------------------------------------------------------------------------
+  // Record: LITERAL, non-space paddingChar '*', RIGHT-aligned (padding on left)
+  // -------------------------------------------------------------------------
+
+  @Record(length = 20)
+  public static class StarPaddingRightAlignRecord {
+    private Status status;
+
+    @Field(offset = 1, length = 10, paddingChar = '*', align = Align.RIGHT)
+    public Status getStatus() { return status; }
+    public void setStatus(Status status) { this.status = status; }
+  }
+
+  // -------------------------------------------------------------------------
+  // Record: NUMERIC, paddingChar '0', RIGHT-aligned (leading zeros)
+  // -------------------------------------------------------------------------
+
+  @Record(length = 20)
+  public static class ZeroPaddingNumericRecord {
+    private Priority priority;
+
+    @Field(offset = 1, length = 3, paddingChar = '0', align = Align.RIGHT)
+    @FixedFormatEnum(EnumFormat.NUMERIC)
+    public Priority getPriority() { return priority; }
+    public void setPriority(Priority priority) { this.priority = priority; }
+  }
+
+  // -------------------------------------------------------------------------
+  // Record: validation failure — enum name too long for @Field length
+  // -------------------------------------------------------------------------
+
+  @Record(length = 10)
+  public static class TooShortFieldRecord {
+    private Status status;
+
+    // Status.INACTIVE is 8 chars, but length is only 3 → should fail validation
+    @Field(offset = 1, length = 3)
+    public Status getStatus() { return status; }
+    public void setStatus(Status status) { this.status = status; }
+  }
+
+  // -------------------------------------------------------------------------
+  // Tests
+  // -------------------------------------------------------------------------
+
+  private final FixedFormatManager manager = new FixedFormatManagerImpl();
+
+  // --- LITERAL default ---
+
+  @Test
+  public void literalDefault_load() {
+    LiteralDefaultRecord record = manager.load(LiteralDefaultRecord.class, "ACTIVE    ");
+    assertEquals(Status.ACTIVE, record.getStatus());
+  }
+
+  @Test
+  public void literalDefault_export() {
+    LiteralDefaultRecord record = new LiteralDefaultRecord();
+    record.setStatus(Status.INACTIVE);
+    String exported = manager.export(record);
+    assertTrue(exported.startsWith("INACTIVE"), "exported string should start with INACTIVE, got: " + exported);
+  }
+
+  @Test
+  public void literalDefault_roundTrip() {
+    LiteralDefaultRecord orig = new LiteralDefaultRecord();
+    orig.setStatus(Status.PENDING);
+    String exported = manager.export(orig);
+    LiteralDefaultRecord loaded = manager.load(LiteralDefaultRecord.class, exported);
+    assertEquals(Status.PENDING, loaded.getStatus());
+  }
+
+  // --- LITERAL explicit ---
+
+  @Test
+  public void literalExplicit_load() {
+    LiteralExplicitRecord record = manager.load(LiteralExplicitRecord.class, "ACTIVE    ");
+    assertEquals(Status.ACTIVE, record.getStatus());
+  }
+
+  @Test
+  public void literalExplicit_roundTrip() {
+    LiteralExplicitRecord orig = new LiteralExplicitRecord();
+    orig.setStatus(Status.INACTIVE);
+    String exported = manager.export(orig);
+    LiteralExplicitRecord loaded = manager.load(LiteralExplicitRecord.class, exported);
+    assertEquals(Status.INACTIVE, loaded.getStatus());
+  }
+
+  // --- NUMERIC ---
+
+  @Test
+  public void numeric_load_ordinal0() {
+    NumericRecord record = manager.load(NumericRecord.class, "0 ");
+    assertEquals(Status.ACTIVE, record.getStatus());
+  }
+
+  @Test
+  public void numeric_load_ordinal1() {
+    NumericRecord record = manager.load(NumericRecord.class, "1 ");
+    assertEquals(Status.INACTIVE, record.getStatus());
+  }
+
+  @Test
+  public void numeric_export_inactive() {
+    NumericRecord record = new NumericRecord();
+    record.setStatus(Status.INACTIVE);
+    String exported = manager.export(record);
+    assertEquals("1", exported.substring(0, 1), "INACTIVE has ordinal 1");
+  }
+
+  @Test
+  public void numeric_roundTrip() {
+    NumericRecord orig = new NumericRecord();
+    orig.setStatus(Status.PENDING);
+    String exported = manager.export(orig);
+    NumericRecord loaded = manager.load(NumericRecord.class, exported);
+    assertEquals(Status.PENDING, loaded.getStatus());
+  }
+
+  // -------------------------------------------------------------------------
+  // Non-space paddingChar: '*', LEFT-aligned (padding appended on the right)
+  //
+  // AbstractFixedFormatter.parse() calls stripPadding() which uses
+  // Align.LEFT.remove(value, '*') — strips trailing '*' chars — before
+  // passing the clean value to asObject(). This is why asObject() must NOT
+  // call value.trim() (only strips spaces).
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void starPadding_leftAlign_export() {
+    StarPaddingLeftAlignRecord record = new StarPaddingLeftAlignRecord();
+    record.setStatus(Status.ACTIVE);
+    String exported = manager.export(record);
+    assertEquals("ACTIVE****", exported.substring(0, 10), "LEFT-aligned with '*' padding should be right-padded");
+  }
+
+  @Test
+  public void starPadding_leftAlign_load() {
+    // Align.LEFT.remove("ACTIVE****", '*') → "ACTIVE"
+    StarPaddingLeftAlignRecord record = manager.load(StarPaddingLeftAlignRecord.class, "ACTIVE****          ");
+    assertEquals(Status.ACTIVE, record.getStatus());
+  }
+
+  @Test
+  public void starPadding_leftAlign_roundTrip_active() {
+    StarPaddingLeftAlignRecord orig = new StarPaddingLeftAlignRecord();
+    orig.setStatus(Status.ACTIVE);
+    String exported = manager.export(orig);
+    StarPaddingLeftAlignRecord loaded = manager.load(StarPaddingLeftAlignRecord.class, exported);
+    assertEquals(Status.ACTIVE, loaded.getStatus());
+  }
+
+  @Test
+  public void starPadding_leftAlign_roundTrip_inactive() {
+    StarPaddingLeftAlignRecord orig = new StarPaddingLeftAlignRecord();
+    orig.setStatus(Status.INACTIVE);
+    String exported = manager.export(orig);
+    StarPaddingLeftAlignRecord loaded = manager.load(StarPaddingLeftAlignRecord.class, exported);
+    assertEquals(Status.INACTIVE, loaded.getStatus());
+  }
+
+  // -------------------------------------------------------------------------
+  // Non-space paddingChar: '*', RIGHT-aligned (padding prepended on the left)
+  //
+  // Align.RIGHT.remove("****ACTIVE", '*') → "ACTIVE"
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void starPadding_rightAlign_export() {
+    StarPaddingRightAlignRecord record = new StarPaddingRightAlignRecord();
+    record.setStatus(Status.ACTIVE);
+    String exported = manager.export(record);
+    assertEquals("****ACTIVE", exported.substring(0, 10), "RIGHT-aligned with '*' padding should be left-padded");
+  }
+
+  @Test
+  public void starPadding_rightAlign_load() {
+    // Align.RIGHT.remove("****ACTIVE", '*') → "ACTIVE"
+    StarPaddingRightAlignRecord record = manager.load(StarPaddingRightAlignRecord.class, "****ACTIVE          ");
+    assertEquals(Status.ACTIVE, record.getStatus());
+  }
+
+  @Test
+  public void starPadding_rightAlign_roundTrip_pending() {
+    StarPaddingRightAlignRecord orig = new StarPaddingRightAlignRecord();
+    orig.setStatus(Status.PENDING);
+    String exported = manager.export(orig);
+    StarPaddingRightAlignRecord loaded = manager.load(StarPaddingRightAlignRecord.class, exported);
+    assertEquals(Status.PENDING, loaded.getStatus());
+  }
+
+  // -------------------------------------------------------------------------
+  // Non-space paddingChar: '0', NUMERIC mode, RIGHT-aligned (leading zeros)
+  //
+  // ordinal 1 → "1" → RIGHT.apply("1", 3, '0') → "001"
+  // parsing "001" → RIGHT.remove("001", '0') → "1" → ordinal 1 → MEDIUM
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void zeroPadding_numeric_rightAlign_export_high() {
+    ZeroPaddingNumericRecord record = new ZeroPaddingNumericRecord();
+    record.setPriority(Priority.HIGH);  // ordinal 2
+    String exported = manager.export(record);
+    assertEquals("002", exported.substring(0, 3), "HIGH (ordinal 2) should be exported as '002'");
+  }
+
+  @Test
+  public void zeroPadding_numeric_rightAlign_load_medium() {
+    // "001" → strip leading '0' via RIGHT.remove → "1" → ordinal 1 → MEDIUM
+    ZeroPaddingNumericRecord record = manager.load(ZeroPaddingNumericRecord.class, "001                ");
+    assertEquals(Priority.MEDIUM, record.getPriority());
+  }
+
+  @Test
+  public void zeroPadding_numeric_rightAlign_load_high() {
+    // "002" → strip leading '0' → "2" → ordinal 2 → HIGH
+    ZeroPaddingNumericRecord record = manager.load(ZeroPaddingNumericRecord.class, "002                ");
+    assertEquals(Priority.HIGH, record.getPriority());
+  }
+
+  @Test
+  public void zeroPadding_numeric_rightAlign_roundTrip_high() {
+    ZeroPaddingNumericRecord orig = new ZeroPaddingNumericRecord();
+    orig.setPriority(Priority.HIGH);  // ordinal 2 → "002" → strip → "2" → ordinal 2 → HIGH
+    String exported = manager.export(orig);
+    ZeroPaddingNumericRecord loaded = manager.load(ZeroPaddingNumericRecord.class, exported);
+    assertEquals(Priority.HIGH, loaded.getPriority());
+  }
+
+  // -------------------------------------------------------------------------
+  // Validation tests
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void validation_enumNameTooLongForField_throwsException() {
+    // Status.INACTIVE = 8 chars, but @Field length = 3 → validation should reject
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.load(TooShortFieldRecord.class, "ACT"));
+    assertTrue(ex.getMessage().contains("max length"), "exception should mention max length: " + ex.getMessage());
+  }
+
+  @Test
+  public void invalidEnumName_throwsFixedFormatException() {
+    // "UNKNOWN" is not a valid Status constant
+    assertThrows(FixedFormatException.class,
+        () -> manager.load(LiteralDefaultRecord.class, "UNKNOWN   "));
+  }
+
+  @Test
+  public void invalidOrdinal_throwsFixedFormatException() {
+    // ordinal 99 is out of range for Status (which has 3 constants)
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.load(NumericRecord.class, "99"));
+    // The manager wraps it in ParseException; the cause carries "out of range"
+    assertNotNull(ex.getCause(), "cause should be present");
+    assertTrue(ex.getCause().getMessage().contains("out of range"),
+        "cause should mention out of range: " + ex.getCause().getMessage());
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `@FixedFormatEnum` and `EnumFormat` annotations for mapping Java enums to/from fixed-width fields
- Implements `EnumFormatter` with configurable serialized value and non-space padding char support
- Wires enum support into `ByTypeFormatter` and `FormatInstructionsBuilder`

## Test plan

- [ ] Run `mvn test -pl fixedformat4j -Dtest=TestIssue67EnumSupport` to verify all enum scenarios pass
- [ ] Run `mvn test` to confirm no regressions in the full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)