### PR TITLE
perf: replace Method.invoke() with MethodHandle for faster dispatch (issue #75)

### DIFF
--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AnnotationTarget.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AnnotationTarget.java
@@ -1,5 +1,7 @@
 package com.ancientprogramming.fixedformat4j.format.impl;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 
@@ -16,10 +18,16 @@ class AnnotationTarget {
 
   final Method getter;
   final AnnotatedElement annotationSource;
+  final MethodHandle getterHandle;
 
   private AnnotationTarget(Method getter, AnnotatedElement annotationSource) {
     this.getter = getter;
     this.annotationSource = annotationSource;
+    try {
+      this.getterHandle = MethodHandles.lookup().unreflect(getter);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("Cannot create MethodHandle for " + getter, e);
+    }
   }
 
   /** Annotation is on the getter — getter serves as both invoker and annotation source. */

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ClassMetadataCache.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ClassMetadataCache.java
@@ -7,6 +7,8 @@ import com.ancientprogramming.fixedformat4j.format.FixedFormatter;
 import com.ancientprogramming.fixedformat4j.format.FormatContext;
 import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -89,9 +91,10 @@ class ClassMetadataCache {
         : getFixedFormatterInstance(context.getFormatter(), context);
 
     Method setter = resolveSetter(clazz, target.getter, datatype, scanner);
+    MethodHandle setterHandle = toHandle(setter);
 
-    return new FieldDescriptor(target, setter, fieldAnnotation, datatype, context, formatInstructions,
-        formatter, isRepeating, isNestedRecord, isLoadField);
+    return new FieldDescriptor(target, setter, setterHandle, fieldAnnotation, datatype, context,
+        formatInstructions, formatter, isRepeating, isNestedRecord, isLoadField);
   }
 
   private Method resolveSetter(Class<?> clazz, Method getter, Class<?> datatype, AnnotationScanner scanner) {
@@ -100,6 +103,15 @@ class ClassMetadataCache {
       return clazz.getMethod(setterName, datatype);
     } catch (NoSuchMethodException e) {
       return null;
+    }
+  }
+
+  private MethodHandle toHandle(Method method) {
+    if (method == null) return null;
+    try {
+      return MethodHandles.lookup().unreflect(method);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException("Cannot create MethodHandle for " + method, e);
     }
   }
 }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FieldDescriptor.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FieldDescriptor.java
@@ -5,6 +5,7 @@ import com.ancientprogramming.fixedformat4j.format.FixedFormatter;
 import com.ancientprogramming.fixedformat4j.format.FormatContext;
 import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
 
+import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Method;
 
 /**
@@ -23,6 +24,7 @@ class FieldDescriptor {
 
   final AnnotationTarget target;
   final Method setter;
+  final MethodHandle setterHandle;
   final Field fieldAnnotation;
   final Class<?> datatype;
   final FormatContext<?> context;
@@ -41,6 +43,7 @@ class FieldDescriptor {
   FieldDescriptor(
       AnnotationTarget target,
       Method setter,
+      MethodHandle setterHandle,
       Field fieldAnnotation,
       Class<?> datatype,
       FormatContext<?> context,
@@ -51,6 +54,7 @@ class FieldDescriptor {
       boolean isLoadField) {
     this.target = target;
     this.setter = setter;
+    this.setterHandle = setterHandle;
     this.fieldAnnotation = fieldAnnotation;
     this.datatype = datatype;
     this.context = context;

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
@@ -95,10 +95,10 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
         }
       }
 
-      if (value != null && desc.setter != null) {
+      if (value != null && desc.setterHandle != null) {
         try {
-          desc.setter.invoke(instance, value);
-        } catch (Exception e) {
+          desc.setterHandle.invoke(instance, value);
+        } catch (Throwable e) {
           throw new FixedFormatException(
               format("could not invoke method %s.%s(%s)", fixedFormatRecordClass.getName(), desc.setter.getName(), desc.datatype), e);
         }
@@ -130,8 +130,8 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
 
       Object valueObject;
       try {
-        valueObject = desc.target.getter.invoke(fixedFormatRecord);
-      } catch (Exception e) {
+        valueObject = desc.target.getterHandle.invoke(fixedFormatRecord);
+      } catch (Throwable e) {
         throw new FixedFormatException(
             format("could not invoke method %s.%s(%s)", fixedFormatRecord.getClass().getName(), desc.target.getter.getName(), desc.datatype), e);
       }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/RepeatingFieldSupport.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/RepeatingFieldSupport.java
@@ -78,8 +78,8 @@ class RepeatingFieldSupport {
 
     Object value;
     try {
-      value = target.getter.invoke(fixedFormatRecord);
-    } catch (Exception e) {
+      value = target.getterHandle.invoke(fixedFormatRecord);
+    } catch (Throwable e) {
       throw new FixedFormatException(format("could not invoke %s", fieldLabel(target.getter)), e);
     }
 

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestClassMetadataCache.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestClassMetadataCache.java
@@ -31,7 +31,9 @@ class TestClassMetadataCache {
     for (FieldDescriptor d : cache.get(MyRecord.class)) {
       String name = d.target.getter.getName();
       assertNotNull(d.target, name + ": target");
+      assertNotNull(d.target.getterHandle, name + ": getterHandle");
       assertNotNull(d.setter, name + ": setter");
+      assertNotNull(d.setterHandle, name + ": setterHandle");
       assertNotNull(d.fieldAnnotation, name + ": fieldAnnotation");
       assertNotNull(d.datatype, name + ": datatype");
       assertNotNull(d.context, name + ": context");


### PR DESCRIPTION
## Summary

- Adds `getterHandle` (`MethodHandle`) to `AnnotationTarget`, created once via `MethodHandles.lookup().unreflect(getter)` during cache build
- Adds `setterHandle` (`MethodHandle`) to `FieldDescriptor`, populated in `ClassMetadataCache.buildDescriptor()`
- Replaces all three `Method.invoke()` call sites with `MethodHandle.invoke()` in `FixedFormatManagerImpl` (load + export) and `RepeatingFieldSupport` (repeating field export)
- Updates catch blocks from `Exception` to `Throwable` to match `MethodHandle.invoke()`'s checked throws signature

## Test plan

- [x] `TestClassMetadataCache` — asserts `getterHandle` and `setterHandle` are non-null for all simple field descriptors
- [x] Full suite (386 tests) green — all load/export behaviour unchanged
- [x] Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)