### PR TITLE
feat: activate nullChar when nullChar == paddingChar (#84)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,32 @@ title: Changelog
 
 # Changelog
 
+## 1.7.2 (unreleased)
+
+### Behaviour changes
+
+- **`@Field(nullChar = …)` now activates when `nullChar == paddingChar`** ([#84](https://github.com/jeyben/fixedformat4j/issues/84)) —
+  The activation gate for null-aware handling is relaxed so that setting `nullChar` equal to
+  `paddingChar` is a supported, idiomatic configuration — the "blank-is-null" convention.
+  Previously this combination was documented as a no-op; it now enables the same load and
+  export semantics as the distinct-sentinel configuration.
+
+  Typical uses:
+
+  ```java
+  // All spaces means null (e.g. optional date)
+  @Field(offset = 1, length = 8, paddingChar = ' ', nullChar = ' ')
+  public Date getInvoiceDate() { … }
+
+  // All zeros means null (e.g. optional numeric with zero-padding)
+  @Field(offset = 9, length = 5, align = Align.RIGHT, paddingChar = '0', nullChar = '0')
+  public Integer getQuantity() { … }
+  ```
+
+  **Migration:** the prior `nullChar != paddingChar` activation rule is removed from the
+  javadoc. Records that intentionally set `nullChar == paddingChar` to get no-op behaviour
+  (none known) should omit `nullChar` instead.
+
 ## 1.7.1 (2026-04-18)
 
 ### New features

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -114,7 +114,7 @@ public class Invoice {
 - Blank slice `"    "` → setter skipped → `repairHours` stays at `0`.
 - Non-blank slice `"0042"` → setter invoked → `repairHours = 42`.
 
-The key activation rule: `nullChar` must differ from `paddingChar`. In the example above the field is zero-padded and nulls are encoded as spaces.
+The key activation rule: `nullChar` must be explicitly set (anything other than the default `'\0'` sentinel). Since 1.7.2, setting `nullChar == paddingChar` also works and enables the "blank-is-null" convention — useful when you do not have a distinct sentinel character available (e.g. all-spaces dates, all-zeros numerics).
 
 **For primitive types (`int`, `long`, `double`, etc.) — use a lenient formatter subclass:**
 

--- a/docs/usage/annotations.md
+++ b/docs/usage/annotations.md
@@ -31,7 +31,7 @@ When placed on a field, the manager derives the getter and setter by name conven
 | `formatter` | `Class<FixedFormatter>` | no | `ByTypeFormatter.class` | The formatter to use when reading and writing the field. |
 | `count` | `int` | no | `1` | Number of consecutive repetitions of this field. When greater than 1, the getter/setter must use an array or an ordered `Collection` (`List`, `Set`, `SortedSet`, etc.). Each repetition occupies `length` characters, starting at `offset + length * index`. |
 | `strictCount` | `boolean` | no | `true` | Only relevant when `count > 1`. If `true` (default), a size mismatch between the array/collection and `count` during export throws a `FixedFormatException`. If `false`, a warning is logged and export proceeds with `min(count, actualSize)` elements. |
-| `nullChar` | `char` | no | `'\0'` | Sentinel character that represents a null value. Null-aware handling is enabled only when `nullChar` differs from `paddingChar`. On load: if every character in the field slice equals `nullChar`, the setter is not invoked and the field remains `null`. On export: if the getter returns `null`, the field is emitted as `nullChar` repeated `length` times, bypassing the formatter. For repeating fields (`count > 1`) the check is applied per element. |
+| `nullChar` | `char` | no | `'\0'` | Sentinel character that represents a null value. Null-aware handling is enabled whenever `nullChar` is explicitly set (i.e. differs from the default `'\0'`). On load: if every character in the field slice equals `nullChar`, the setter is not invoked and the field remains `null`. On export: if the getter returns `null`, the field is emitted as `nullChar` repeated `length` times, bypassing the formatter. Setting `nullChar == paddingChar` (since 1.7.2) enables the "blank-is-null" convention — an all-padding slice loads as `null`. For repeating fields (`count > 1`) the check is applied per element. |
 
 **Alignment values:**
 
@@ -67,10 +67,10 @@ Supported return types for `count > 1`: `T[]` (array), `List`, `LinkedList`, `Se
 
 By default a fixed-width field has no concept of null — an all-spaces field loads as an empty string or zero, not `null`. The `nullChar` attribute opts a single field into null-aware handling by designating a sentinel character.
 
-**Activation rule:** null-aware handling is enabled only when `nullChar` differs from `paddingChar`. The built-in default (`'\0'`) can never appear in a real fixed-width payload, so all existing fields retain their pre-1.7.1 behaviour unless you explicitly set `nullChar`.
+**Activation rule:** null-aware handling is enabled whenever `nullChar` is explicitly set (i.e. differs from the default sentinel `'\0'`, which can never appear in a real fixed-width payload). Existing fields that do not set `nullChar` retain their pre-1.7.1 behaviour.
 
 ```java
-// "     " (five spaces) → null   "00042" → 42
+// Distinct sentinel: "     " (five spaces) → null   "00042" → 42
 @Field(offset = 1, length = 5, align = Align.RIGHT, paddingChar = '0', nullChar = ' ')
 public Integer getAmount() { return amount; }
 public void setAmount(Integer amount) { this.amount = amount; }
@@ -80,6 +80,18 @@ public void setAmount(Integer amount) { this.amount = amount; }
 - **On export** — if the getter returns `null`, the field is emitted as `nullChar` × `length`, bypassing the formatter entirely.
 
 For repeating fields (`count > 1`) the check is applied **per element**: each slot is evaluated independently, so a collection can hold a mix of `null` and non-null values. Primitive array element types (e.g. `int[]`) cannot hold `null` and are unaffected.
+
+**Blank-is-null** (since 1.7.2): setting `nullChar == paddingChar` activates the "fully-padded slice means null" convention — typical for all-spaces dates and all-zeros numerics where a distinct sentinel character is not available.
+
+```java
+// All spaces → null, otherwise a value
+@Field(offset = 1, length = 8, paddingChar = ' ', nullChar = ' ')
+public Date getInvoiceDate() { return invoiceDate; }
+
+// All zeros → null, otherwise a zero-padded integer
+@Field(offset = 9, length = 5, align = Align.RIGHT, paddingChar = '0', nullChar = '0')
+public Integer getQuantity() { return quantity; }
+```
 
 ## @Fields
 

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Field.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Field.java
@@ -73,8 +73,11 @@ public @interface Field {
   /**
    * Opt-in sentinel used to represent a {@code null} value in the fixed-width field.
    * <p>
-   * Activation rule: null-aware handling fires only when {@code nullChar() != paddingChar()}.
-   * When active:
+   * Activation rule: null-aware handling fires whenever {@code nullChar()} differs from
+   * the {@link #UNSET_NULL_CHAR} sentinel. Configuring {@code nullChar() == paddingChar()}
+   * is supported since 1.7.2 and enables the idiomatic "blank-is-null" convention &mdash;
+   * e.g. an all-spaces date or an all-zeros numeric loads as {@code null} and exports
+   * back to the same fully-padded form. When active:
    * <ul>
    *   <li>On load, a slice whose characters all equal {@code nullChar} yields {@code null}
    *       (the setter is not invoked). Configuring {@code nullChar} on a primitive-typed

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/NullCharSupport.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/NullCharSupport.java
@@ -16,13 +16,14 @@ final class NullCharSupport {
   private NullCharSupport() {}
 
   /**
-   * Returns {@code true} when {@code @Field.nullChar()} is explicitly configured (non-sentinel)
-   * and differs from {@code @Field.paddingChar()}. The sentinel {@link com.ancientprogramming.fixedformat4j.annotation.Field#UNSET_NULL_CHAR}
-   * marks "not configured" and is never treated as a real null character.
+   * Returns {@code true} when {@code @Field.nullChar()} is explicitly configured (non-sentinel).
+   * The sentinel {@link com.ancientprogramming.fixedformat4j.annotation.Field#UNSET_NULL_CHAR}
+   * marks "not configured" and is never treated as a real null character. Setting
+   * {@code nullChar} equal to {@code paddingChar} activates the "blank-is-null" convention
+   * (Issue 84).
    */
   static boolean isNullCharActive(FormatInstructions instructions) {
-    char nullChar = instructions.getNullChar();
-    return nullChar != UNSET_NULL_CHAR && nullChar != instructions.getPaddingChar();
+    return instructions.getNullChar() != UNSET_NULL_CHAR;
   }
 
   /**

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/issues/TestIssue29.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/issues/TestIssue29.java
@@ -33,11 +33,11 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * Verifies Issue 29 - distinguish "no data" from zero/empty via an opt-in
  * {@code nullChar} attribute on {@link Field}.
  *
- * <p>When {@code nullChar} is set to a character different from {@code paddingChar},
- * the manager treats a field fully filled with {@code nullChar} as {@code null} on
- * load, and serializes {@code null} values as {@code length × nullChar} on export.
- * When {@code nullChar == paddingChar} (the default case), detection is disabled
- * and existing behavior is preserved.
+ * <p>Whenever {@code nullChar} is explicitly set (i.e. differs from the
+ * {@code UNSET_NULL_CHAR} sentinel), the manager treats a field fully filled with
+ * {@code nullChar} as {@code null} on load, and serializes {@code null} values as
+ * {@code length × nullChar} on export. This includes the {@code nullChar == paddingChar}
+ * "blank-is-null" configuration (see Issue 84).
  *
  * @since 1.7.1
  */
@@ -231,10 +231,11 @@ public class TestIssue29 {
   }
 
   @Test
-  public void nullCharEqualsPaddingChar_detectionDisabled() {
-    // When explicitly set equal, detection must stay off.
+  public void nullCharEqualsPaddingChar_detectionActive() {
+    // Issue 84: when nullChar is explicitly set, detection is active even when
+    // nullChar equals paddingChar — this is the idiomatic "blank-is-null" configuration.
     SameCharRecord29 loaded = manager.load(SameCharRecord29.class, "     ");
-    assertEquals(Integer.valueOf(0), loaded.getIntegerData());
+    assertNull(loaded.getIntegerData());
   }
 
   // ---------------------------------------------------------------------------

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/issues/TestIssue84BlankIsNull.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/issues/TestIssue84BlankIsNull.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2004 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ancientprogramming.fixedformat4j.issues;
+
+import com.ancientprogramming.fixedformat4j.annotation.Align;
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.Record;
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
+import com.ancientprogramming.fixedformat4j.format.impl.FixedFormatManagerImpl;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies Issue 84 &mdash; a fully-padded slice loads as {@code null} when
+ * {@code nullChar == paddingChar} (the "blank-is-null" convention).
+ *
+ * <p>The activation gate for {@code nullChar} is relaxed so that setting
+ * {@code nullChar} to the same character as {@code paddingChar} enables
+ * null-aware handling. The idiomatic use cases are all-spaces dates and
+ * all-zeros numerics.
+ *
+ * @since 1.7.2
+ */
+public class TestIssue84BlankIsNull {
+
+  private final FixedFormatManager manager = new FixedFormatManagerImpl();
+
+  // ---------------------------------------------------------------------------
+  // Space-padded reference type -> all-spaces is null
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void loadAllSpacesOnStringField_returnsNull() {
+    SpacePaddedStringRecord loaded = manager.load(SpacePaddedStringRecord.class, "        ");
+    assertNull(loaded.getDescription());
+  }
+
+  @Test
+  public void exportNullOnStringField_emitsAllSpaces() {
+    SpacePaddedStringRecord record = new SpacePaddedStringRecord();
+    record.setDescription(null);
+    assertEquals("        ", manager.export(record));
+  }
+
+  @Test
+  public void roundTripNonNullValueOnStringField_isPreserved() {
+    SpacePaddedStringRecord record = new SpacePaddedStringRecord();
+    record.setDescription("ABC");
+    String exported = manager.export(record);
+    assertEquals("ABC     ", exported);
+    SpacePaddedStringRecord reloaded = manager.load(SpacePaddedStringRecord.class, exported);
+    assertEquals("ABC", reloaded.getDescription());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Zero-padded numeric -> all-zeros is null
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void loadAllZerosOnIntegerField_returnsNull() {
+    ZeroPaddedIntegerRecord loaded = manager.load(ZeroPaddedIntegerRecord.class, "00000");
+    assertNull(loaded.getQuantity());
+  }
+
+  @Test
+  public void loadNonZeroOnIntegerField_returnsValue() {
+    ZeroPaddedIntegerRecord loaded = manager.load(ZeroPaddedIntegerRecord.class, "00042");
+    assertEquals(Integer.valueOf(42), loaded.getQuantity());
+  }
+
+  @Test
+  public void exportNullOnIntegerField_emitsAllZeros() {
+    ZeroPaddedIntegerRecord record = new ZeroPaddedIntegerRecord();
+    record.setQuantity(null);
+    assertEquals("00000", manager.export(record));
+  }
+
+  @Test
+  public void exportValueOnIntegerField_emitsZeroPaddedDigits() {
+    ZeroPaddedIntegerRecord record = new ZeroPaddedIntegerRecord();
+    record.setQuantity(42);
+    assertEquals("00042", manager.export(record));
+  }
+
+  // ---------------------------------------------------------------------------
+  // POJO field default preserved when null-slice detected
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void loadAllZerosOnRecordWithPojoDefault_preservesDefault() {
+    PojoDefaultRecord loaded = manager.load(PojoDefaultRecord.class, "00000");
+    assertEquals(Integer.valueOf(99), loaded.getQuantity());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Repeating field per-element detection with nullChar == paddingChar
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void loadRepeatingStringField_blankElementBecomesNull() {
+    RepeatingSpacePaddedRecord loaded = manager.load(RepeatingSpacePaddedRecord.class, "ABC   XYZ");
+    List<String> codes = loaded.getCodes();
+    assertEquals(3, codes.size());
+    assertEquals("ABC", codes.get(0));
+    assertNull(codes.get(1));
+    assertEquals("XYZ", codes.get(2));
+  }
+
+  @Test
+  public void exportRepeatingStringFieldWithNullElement_emitsAllSpacesForNull() {
+    RepeatingSpacePaddedRecord record = new RepeatingSpacePaddedRecord();
+    record.setCodes(new ArrayList<>(Arrays.asList("ABC", null, "XYZ")));
+    assertEquals("ABC   XYZ", manager.export(record));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Primitive validation still rejects when nullChar == paddingChar
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void load_blankIsNullOnPrimitive_throwsFixedFormatException() {
+    assertThrows(FixedFormatException.class,
+        () -> manager.load(PrimitiveBlankIsNullRecord.class, "     "));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Record definitions
+  // ---------------------------------------------------------------------------
+
+  @Record(length = 8)
+  public static class SpacePaddedStringRecord {
+
+    private String description;
+
+    @Field(offset = 1, length = 8, paddingChar = ' ', nullChar = ' ')
+    public String getDescription() {
+      return description;
+    }
+
+    public void setDescription(String description) {
+      this.description = description;
+    }
+  }
+
+  @Record(length = 5)
+  public static class ZeroPaddedIntegerRecord {
+
+    private Integer quantity;
+
+    @Field(offset = 1, length = 5, align = Align.RIGHT, paddingChar = '0', nullChar = '0')
+    public Integer getQuantity() {
+      return quantity;
+    }
+
+    public void setQuantity(Integer quantity) {
+      this.quantity = quantity;
+    }
+  }
+
+  @Record(length = 5)
+  public static class PojoDefaultRecord {
+
+    private Integer quantity = 99;
+
+    @Field(offset = 1, length = 5, align = Align.RIGHT, paddingChar = '0', nullChar = '0')
+    public Integer getQuantity() {
+      return quantity;
+    }
+
+    public void setQuantity(Integer quantity) {
+      this.quantity = quantity;
+    }
+  }
+
+  @Record(length = 9)
+  public static class RepeatingSpacePaddedRecord {
+
+    private List<String> codes;
+
+    @Field(offset = 1, length = 3, count = 3, paddingChar = ' ', nullChar = ' ')
+    public List<String> getCodes() {
+      return codes;
+    }
+
+    public void setCodes(List<String> codes) {
+      this.codes = codes;
+    }
+  }
+
+  @Record(length = 5)
+  public static class PrimitiveBlankIsNullRecord {
+
+    private int hours;
+
+    @Field(offset = 1, length = 5, paddingChar = ' ', nullChar = ' ')
+    public int getHours() {
+      return hours;
+    }
+
+    public void setHours(int hours) {
+      this.hours = hours;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Relax `NullCharSupport.isNullCharActive` so `@Field(nullChar = paddingChar)` activates null-aware handling — the idiomatic "blank-is-null" convention (all-spaces dates, all-zeros numerics).
- Flip the single backward-compat assertion in `TestIssue29.nullCharEqualsPaddingChar_detectionDisabled` → `detectionActive`.
- Update javadoc on `Field.nullChar`, `NullCharSupport.isNullCharActive`, and the user docs (`annotations.md`, `changelog.md` 1.7.2 entry, `faq.md` note).

Closes #84. See the [plan comment on issue #84](https://github.com/jeyben/fixedformat4j/issues/84#issuecomment-4283680019) for the agreed approach.

### Behaviour change

Previously the `nullChar != paddingChar` activation gate documented the equal-char combination as a no-op. It now enables:

```java
// All spaces → null   (blank-is-null)
@Field(offset = 1, length = 8, paddingChar = ' ', nullChar = ' ')
public Date getInvoiceDate() { return invoiceDate; }

// All zeros → null   (the case nullChar could not express before)
@Field(offset = 9, length = 5, align = Align.RIGHT, paddingChar = '0', nullChar = '0')
public Integer getQuantity() { return quantity; }
```

Existing records without `nullChar` retain their pre-1.7.1 behaviour — the `UNSET_NULL_CHAR` sentinel is unchanged.

## Test plan

- [x] `TestIssue84BlankIsNull` — 11 new tests covering space-padded string, zero-padded Integer, POJO field default preservation, repeating field per-element detection, primitive rejection, and round-trip.
- [x] `TestIssue29.nullCharEqualsPaddingChar_detectionActive` — inverted assertion and updated class javadoc.
- [x] Full suite: `mvn test -pl fixedformat4j` → **447/447 green** on Java 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)