### PR TITLE
fix: replace ConcurrentHashMap caches with ClassValue to prevent classloader leaks

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,28 @@ title: Changelog
 
 # Changelog
 
+## [Unreleased] — 1.8.0
+
+### Bug fixes
+
+- **Classloader leak prevention via `ClassValue`** ([#89](https://github.com/jeyben/fixedformat4j/issues/89)) —
+  The three JVM-level caches (`ClassMetadataCache`, `FixedFormatManagerImpl.VALIDATED_CLASSES`, and
+  `AbstractPatternFormatter.PATTERN_LENGTH_CACHE`) were backed by static
+  `ConcurrentHashMap<Class<?>, …>` instances. A `ConcurrentHashMap` holds **strong references** to
+  its keys, so a `Class` used as a key can never be garbage-collected — even after all application
+  references to it are gone. In multi-classloader environments (OSGi, servlet containers, Spring
+  Boot DevTools, Jakarta EE) this causes the child `ClassLoader` that defined the record class to
+  be retained indefinitely, leaking all classes it loaded.
+
+  All three caches are now backed by `ClassValue<T>`. Computed values are stored inside the
+  `Class` object itself; when the record class's defining `ClassLoader` becomes unreachable the
+  cached metadata is collected with it — no external map, no leak.
+
+  **No API or behaviour change.** Existing annotated record classes, custom formatters, and
+  serialized fixed-width data are unaffected.
+
+---
+
 ## 1.7.2 (2026-04-20)
 
 ### Behaviour changes

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AbstractPatternFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AbstractPatternFormatter.java
@@ -18,7 +18,6 @@ package com.ancientprogramming.fixedformat4j.format.impl;
 import com.ancientprogramming.fixedformat4j.format.AbstractFixedFormatter;
 import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
 
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -40,7 +39,14 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public abstract class AbstractPatternFormatter<T> extends AbstractFixedFormatter<T> {
 
-  private static final Map<Class<?>, Map<String, Integer>> PATTERN_LENGTH_CACHE = new ConcurrentHashMap<>();
+  // Keyed by formatter Class; values are collected when the formatter class's classloader is GC'd.
+  private static final ClassValue<ConcurrentHashMap<String, Integer>> PATTERN_LENGTH_CACHE =
+      new ClassValue<ConcurrentHashMap<String, Integer>>() {
+        @Override
+        protected ConcurrentHashMap<String, Integer> computeValue(Class<?> type) {
+          return new ConcurrentHashMap<>();
+        }
+      };
 
   /**
    * Strips padding, then re-applies it when the padding character overlaps with
@@ -68,8 +74,7 @@ public abstract class AbstractPatternFormatter<T> extends AbstractFixedFormatter
   }
 
   protected final int formattedLengthForPattern(String pattern) {
-    return PATTERN_LENGTH_CACHE
-        .computeIfAbsent(getClass(), k -> new ConcurrentHashMap<>())
+    return PATTERN_LENGTH_CACHE.get(getClass())
         .computeIfAbsent(pattern, this::computeFormattedLengthForPattern);
   }
 

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AbstractPatternFormatter.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AbstractPatternFormatter.java
@@ -33,6 +33,11 @@ import java.util.concurrent.ConcurrentHashMap;
  * for the pattern, it is re-padded to that length so that the underlying date parser
  * receives a well-formed string.
  *
+ * <p>The formatted length for each pattern is computed once per (formatter subclass, pattern)
+ * pair and cached in a {@link ClassValue}-backed map. Values are automatically eligible for GC
+ * when the formatter's defining classloader is collected, preventing classloader leaks in
+ * hot-reload and multi-classloader environments.
+ *
  * @param <T> the date/time type handled by this formatter
  * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.6.1

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ClassMetadataCache.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ClassMetadataCache.java
@@ -13,8 +13,6 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static com.ancientprogramming.fixedformat4j.format.FixedFormatUtil.getFixedFormatterInstance;
 
@@ -25,15 +23,14 @@ import static com.ancientprogramming.fixedformat4j.format.FixedFormatUtil.getFix
  * {@link FieldDescriptor} per effective {@code @Field}. Subsequent calls return the same
  * immutable list without re-scanning.
  *
- * <p>Thread safety: {@code computeIfAbsent} guarantees that {@link #build} runs at most once per
+ * <p>Thread safety: {@link ClassValue} guarantees that {@link #build} runs at most once per
  * class key. Helper objects ({@link AnnotationScanner}, {@link FormatInstructionsBuilder},
  * {@link RepeatingFieldSupport}) are created as local variables inside {@code build} so that
  * concurrent builds of different classes never share mutable state.
  *
- * <p><strong>Note:</strong> this cache is never cleared. In multi-classloader environments
- * (e.g. application servers with hot-reload, OSGi containers) old {@link Class} references may
- * be retained here after their classloader is discarded, preventing garbage collection.
- * In such environments consider using a {@link java.lang.ref.WeakReference}-based map instead.
+ * <p>Classloader safety: values are stored inside each {@link Class} object via {@link ClassValue},
+ * so they are automatically eligible for GC once the defining classloader becomes unreachable.
+ * This prevents classloader leaks in hot-reload and multi-classloader environments.
  *
  * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.7.0
@@ -42,10 +39,15 @@ class ClassMetadataCache {
 
   static final ClassMetadataCache INSTANCE = new ClassMetadataCache();
 
-  private final Map<Class<?>, List<FieldDescriptor>> cache = new ConcurrentHashMap<>();
+  private final ClassValue<List<FieldDescriptor>> cache = new ClassValue<List<FieldDescriptor>>() {
+    @Override
+    protected List<FieldDescriptor> computeValue(Class<?> clazz) {
+      return build(clazz);
+    }
+  };
 
   List<FieldDescriptor> get(Class<?> clazz) {
-    return cache.computeIfAbsent(clazz, this::build);
+    return cache.get(clazz);
   }
 
   private List<FieldDescriptor> build(Class<?> clazz) {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
@@ -34,10 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static com.ancientprogramming.fixedformat4j.format.FixedFormatUtil.fetchData;
 import static java.lang.String.format;
@@ -53,17 +50,23 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
   private static final Logger LOG = LoggerFactory.getLogger(FixedFormatManagerImpl.class);
 
   /**
-   * JVM-level cache of record classes whose enum-field lengths have already been validated.
-   * Validation is performed at most once per class (on the first {@code load} or {@code export}
-   * call) and then skipped for subsequent calls.
-   * <p>
-   * <strong>Note:</strong> this set is never cleared. In multi-classloader environments
-   * (e.g. application servers with hot-reload, OSGi containers) old {@link Class} references
-   * may be retained here after their classloader is discarded, preventing garbage collection.
-   * In such environments consider using a {@link java.lang.ref.WeakReference}-based map instead.
-   * </p>
+   * Tracks which record classes have already been validated. The sentinel value is stored inside
+   * each {@link Class} object via {@link ClassValue}, so it is automatically GC'd when the
+   * defining classloader becomes unreachable — preventing classloader leaks in hot-reload and
+   * multi-classloader environments. {@link ClassValue#computeValue} is invoked at most once per
+   * class, ensuring validation runs exactly once per class per JVM lifetime.
    */
-  private static final Set<Class<?>> VALIDATED_CLASSES = Collections.newSetFromMap(new ConcurrentHashMap<>());
+  private static final ClassValue<Boolean> VALIDATED_CLASSES = new ClassValue<Boolean>() {
+    @Override
+    protected Boolean computeValue(Class<?> clazz) {
+      for (FieldDescriptor desc : ClassMetadataCache.INSTANCE.get(clazz)) {
+        doValidateFieldPattern(desc.target, desc.fieldAnnotation);
+        doValidateEnumFieldLength(desc.target, desc.fieldAnnotation);
+        doValidateFieldNullChar(desc.target, desc.fieldAnnotation);
+      }
+      return Boolean.TRUE;
+    }
+  };
 
   private final RecordInstantiator recordInstantiator = new RecordInstantiator();
   private final RepeatingFieldSupport repeatingFieldSupport = new RepeatingFieldSupport();
@@ -176,19 +179,11 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
   }
 
   private void validatePatterns(Class<?> recordClass) {
-    if (VALIDATED_CLASSES.contains(recordClass)) {
-      return;
-    }
-    for (FieldDescriptor desc : ClassMetadataCache.INSTANCE.get(recordClass)) {
-      validateFieldPattern(desc.target, desc.fieldAnnotation);
-      validateEnumFieldLength(desc.target, desc.fieldAnnotation);
-      validateFieldNullChar(desc.target, desc.fieldAnnotation);
-    }
-    VALIDATED_CLASSES.add(recordClass);
+    VALIDATED_CLASSES.get(recordClass);
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})
-  private void validateEnumFieldLength(AnnotationTarget target, Field fieldAnnotation) {
+  private static void doValidateEnumFieldLength(AnnotationTarget target, Field fieldAnnotation) {
     FormatInstructionsBuilder instructionsBuilder = new FormatInstructionsBuilder();
     Class<?> datatype = instructionsBuilder.datatype(target.getter, fieldAnnotation);
     if (!datatype.isEnum()) {
@@ -217,12 +212,12 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
     }
   }
 
-  private void validateFieldNullChar(AnnotationTarget target, Field fieldAnnotation) {
+  private static void doValidateFieldNullChar(AnnotationTarget target, Field fieldAnnotation) {
     if (fieldAnnotation.nullChar() == Field.UNSET_NULL_CHAR) return;
 
     Class<?> typeToCheck;
     if (fieldAnnotation.count() > 1) {
-      typeToCheck = repeatingFieldSupport.resolveElementType(target.getter);
+      typeToCheck = new RepeatingFieldSupport().resolveElementType(target.getter);
     } else {
       FormatInstructionsBuilder instructionsBuilder = new FormatInstructionsBuilder();
       typeToCheck = instructionsBuilder.datatype(target.getter, fieldAnnotation);
@@ -237,7 +232,7 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
     }
   }
 
-  private void validateFieldPattern(AnnotationTarget target, Field fieldAnnotation) {
+  private static void doValidateFieldPattern(AnnotationTarget target, Field fieldAnnotation) {
     FormatInstructionsBuilder instructionsBuilder = new FormatInstructionsBuilder();
     Class<?> datatype = instructionsBuilder.datatype(target.getter, fieldAnnotation);
     FixedFormatPattern patternAnnotation = target.annotationSource.getAnnotation(FixedFormatPattern.class);

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/ChildFirstURLClassLoader.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/ChildFirstURLClassLoader.java
@@ -1,0 +1,38 @@
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * A classloader that skips parent delegation for a single nominated class, forcing the JVM to
+ * define it fresh from the URL array. All other classes are loaded via normal parent delegation.
+ *
+ * <p>Used by classloader-leak tests to simulate the "library in parent, application record in
+ * child" topology that exists in servlet containers and OSGi environments.
+ */
+class ChildFirstURLClassLoader extends URLClassLoader {
+
+  private final String targetClassName;
+
+  ChildFirstURLClassLoader(URL[] urls, ClassLoader parent, String targetClassName) {
+    super(urls, parent);
+    this.targetClassName = targetClassName;
+  }
+
+  @Override
+  protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+    if (name.equals(targetClassName)) {
+      synchronized (getClassLoadingLock(name)) {
+        Class<?> c = findLoadedClass(name);
+        if (c == null) {
+          c = findClass(name);
+        }
+        if (resolve) {
+          resolveClass(c);
+        }
+        return c;
+      }
+    }
+    return super.loadClass(name, resolve);
+  }
+}

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/IsolatedRecord.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/IsolatedRecord.java
@@ -1,0 +1,23 @@
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.Record;
+
+/**
+ * Minimal @Record fixture used in classloader-leak tests.
+ * Loaded by an isolated child classloader so its lifecycle can be tracked.
+ */
+@Record
+public class IsolatedRecord {
+
+  private String data;
+
+  @Field(offset = 1, length = 10)
+  public String getData() {
+    return data;
+  }
+
+  public void setData(String data) {
+    this.data = data;
+  }
+}

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestClassloaderLeak.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestClassloaderLeak.java
@@ -1,0 +1,68 @@
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
+import org.junit.jupiter.api.Test;
+
+import java.lang.ref.WeakReference;
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Verifies that the three JVM-level caches (ClassMetadataCache, AbstractPatternFormatter,
+ * FixedFormatManagerImpl.VALIDATED_CLASSES) do not pin a record class's defining ClassLoader
+ * after all other strong references to that class are released.
+ *
+ * <p>The test simulates the "library in parent, application record in child" classloader topology
+ * that exists in servlet containers, OSGi, and Spring Boot DevTools. It fails if any cache holds
+ * a strong reference to the child-loaded record class (and therefore to its ClassLoader).
+ */
+class TestClassloaderLeak {
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void cachedRecordClassIsGcEligibleAfterLoaderRelease() throws Exception {
+    // Locate test-classes directory so ChildFirstURLClassLoader can find IsolatedRecord.class.
+    URL testClassesUrl = IsolatedRecord.class.getProtectionDomain().getCodeSource().getLocation();
+
+    WeakReference<ClassLoader> loaderRef;
+    {
+      // Simulate child classloader (e.g. a webapp classloader) that loads IsolatedRecord
+      // independently of the parent, which owns the fixedformat4j library.
+      ChildFirstURLClassLoader loader = new ChildFirstURLClassLoader(
+          new URL[]{testClassesUrl},
+          FixedFormatManagerImpl.class.getClassLoader(),
+          IsolatedRecord.class.getName());
+
+      Class<Object> recordCls = (Class<Object>) loader.loadClass(IsolatedRecord.class.getName());
+
+      // Sanity check: the record class must have been defined by the child, not the parent.
+      assertSame(loader, recordCls.getClassLoader(),
+          "IsolatedRecord should be defined by the child classloader");
+      assertNotSame(IsolatedRecord.class, recordCls,
+          "child-loaded IsolatedRecord must be a distinct Class object from the parent-loaded one");
+
+      // Warm up all three caches.
+      FixedFormatManager mgr = new FixedFormatManagerImpl();
+      Object loaded = mgr.load(recordCls, "hello     ");
+      mgr.export(loaded);
+
+      loaderRef = new WeakReference<>(loader);
+      // Drop all strong references to the child-domain objects.
+      // After this block exits, only the WeakReference remains.
+    }
+
+    // Repeatedly hint at GC. ClassValue-based caches should allow the loader to be collected.
+    for (int i = 0; i < 20 && loaderRef.get() != null; i++) {
+      System.gc();
+      Thread.sleep(50);
+    }
+
+    assertNull(loaderRef.get(),
+        "fixedformat4j caches retained the child classloader after all strong references were released. "
+            + "This indicates a classloader leak — the caches hold a strong reference to the "
+            + "child-loaded record Class, which pins the child ClassLoader and all classes it defined.");
+  }
+}

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestClassloaderLeak.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestClassloaderLeak.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
- * Verifies that the three JVM-level caches (ClassMetadataCache, AbstractPatternFormatter,
+ * Verifies that the two JVM-level caches (ClassMetadataCache and
  * FixedFormatManagerImpl.VALIDATED_CLASSES) do not pin a record class's defining ClassLoader
  * after all other strong references to that class are released.
  *
@@ -22,37 +22,10 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 class TestClassloaderLeak {
 
   @Test
-  @SuppressWarnings("unchecked")
   void cachedRecordClassIsGcEligibleAfterLoaderRelease() throws Exception {
-    // Locate test-classes directory so ChildFirstURLClassLoader can find IsolatedRecord.class.
     URL testClassesUrl = IsolatedRecord.class.getProtectionDomain().getCodeSource().getLocation();
 
-    WeakReference<ClassLoader> loaderRef;
-    {
-      // Simulate child classloader (e.g. a webapp classloader) that loads IsolatedRecord
-      // independently of the parent, which owns the fixedformat4j library.
-      ChildFirstURLClassLoader loader = new ChildFirstURLClassLoader(
-          new URL[]{testClassesUrl},
-          FixedFormatManagerImpl.class.getClassLoader(),
-          IsolatedRecord.class.getName());
-
-      Class<Object> recordCls = (Class<Object>) loader.loadClass(IsolatedRecord.class.getName());
-
-      // Sanity check: the record class must have been defined by the child, not the parent.
-      assertSame(loader, recordCls.getClassLoader(),
-          "IsolatedRecord should be defined by the child classloader");
-      assertNotSame(IsolatedRecord.class, recordCls,
-          "child-loaded IsolatedRecord must be a distinct Class object from the parent-loaded one");
-
-      // Warm up all three caches.
-      FixedFormatManager mgr = new FixedFormatManagerImpl();
-      Object loaded = mgr.load(recordCls, "hello     ");
-      mgr.export(loaded);
-
-      loaderRef = new WeakReference<>(loader);
-      // Drop all strong references to the child-domain objects.
-      // After this block exits, only the WeakReference remains.
-    }
+    WeakReference<ClassLoader> loaderRef = warmCachesAndReturnLoaderRef(testClassesUrl);
 
     // Repeatedly hint at GC. ClassValue-based caches should allow the loader to be collected.
     for (int i = 0; i < 20 && loaderRef.get() != null; i++) {
@@ -64,5 +37,38 @@ class TestClassloaderLeak {
         "fixedformat4j caches retained the child classloader after all strong references were released. "
             + "This indicates a classloader leak — the caches hold a strong reference to the "
             + "child-loaded record Class, which pins the child ClassLoader and all classes it defined.");
+  }
+
+  /**
+   * Loads IsolatedRecord in an isolated child classloader, warms the two caches, and returns a
+   * WeakReference to the child classloader. Extracting this into its own method ensures HotSpot
+   * pops the entire stack frame on return, making all locals (loader, recordCls, mgr, loaded)
+   * definitively unreachable before the GC loop runs.
+   */
+  @SuppressWarnings("unchecked")
+  private WeakReference<ClassLoader> warmCachesAndReturnLoaderRef(URL testClassesUrl)
+      throws Exception {
+    // Simulate child classloader (e.g. a webapp classloader) that loads IsolatedRecord
+    // independently of the parent, which owns the fixedformat4j library.
+    ChildFirstURLClassLoader loader = new ChildFirstURLClassLoader(
+        new URL[]{testClassesUrl},
+        FixedFormatManagerImpl.class.getClassLoader(),
+        IsolatedRecord.class.getName());
+
+    Class<Object> recordCls = (Class<Object>) loader.loadClass(IsolatedRecord.class.getName());
+
+    // Sanity check: the record class must have been defined by the child, not the parent.
+    assertSame(loader, recordCls.getClassLoader(),
+        "IsolatedRecord should be defined by the child classloader");
+    assertNotSame(IsolatedRecord.class, recordCls,
+        "child-loaded IsolatedRecord must be a distinct Class object from the parent-loaded one");
+
+    // Warm up the two caches: ClassMetadataCache and FixedFormatManagerImpl.VALIDATED_CLASSES.
+    FixedFormatManager mgr = new FixedFormatManagerImpl();
+    Object loaded = mgr.load(recordCls, "hello     ");
+    mgr.export(loaded);
+
+    return new WeakReference<>(loader);
+    // All locals (loader, recordCls, mgr, loaded) are unreachable once this frame is popped.
   }
 }


### PR DESCRIPTION
Fixes #89

Replaces the three JVM-level `ConcurrentHashMap<Class<?>, …>` caches with `ClassValue<T>` to prevent classloader leaks in multi-classloader environments.

With `ClassValue`, computed values are stored inside the `Class` object itself; when the record class's defining `ClassLoader` becomes unreachable, the cached metadata is collected with it — no external map, no leak.

Includes a new `TestClassloaderLeak` test that verifies the fix using a `ChildFirstURLClassLoader` to simulate the container topology.

Generated with [Claude Code](https://claude.ai/code)