### PR TITLE
feat: introduce RecordAlign enum for @Record(align)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,32 @@ title: Changelog
 
 ## [Unreleased] — 1.8.0
 
+### Breaking changes
+
+- **`@Record(align)` now uses `RecordAlign` instead of `Align`** ([#81](https://github.com/jeyben/fixedformat4j/issues/81)) —
+  A new two-value enum `RecordAlign { LEFT, RIGHT }` replaces `Align` as the type of `@Record#align()`.
+  Because `Align` includes the `INHERIT` sentinel, which has no meaning at the record level, the old
+  type admitted a combination that was only detectable at runtime (and was rejected with a
+  `FixedFormatException` since 1.7.1). `RecordAlign` makes that mistake impossible at compile time
+  and removes the runtime check.
+
+  **Migration:** replace `Align.LEFT` / `Align.RIGHT` with `RecordAlign.LEFT` / `RecordAlign.RIGHT`
+  on every `@Record` annotation that specifies the `align` attribute:
+
+  ```java
+  // Before (1.7.x)
+  @Record(length = 20, align = Align.RIGHT)
+  public class MyRecord { … }
+
+  // After (1.8.0+)
+  @Record(length = 20, align = RecordAlign.RIGHT)
+  public class MyRecord { … }
+  ```
+
+  Records that do not specify `align` are **unaffected** — the default (`RecordAlign.LEFT`)
+  preserves the existing behaviour. The `Align` enum itself is unchanged and continues to be
+  used for `@Field(align = …)`.
+
 ### Bug fixes
 
 - **Classloader leak prevention via `ClassValue`** ([#89](https://github.com/jeyben/fixedformat4j/issues/89)) —

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Record.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Record.java
@@ -46,15 +46,11 @@ public @interface Record {
   /**
    * Default alignment applied to all fields in this record. Individual fields may override this
    * by setting {@link Field#align()} to any value other than {@link Align#INHERIT}.
-   * Defaults to {@link Align#LEFT} to preserve pre-1.7.1 behaviour for records that do not
+   * Defaults to {@link RecordAlign#LEFT} to preserve pre-1.7.1 behaviour for records that do not
    * set this attribute.
-   * <p>
-   * {@link Align#INHERIT} is not a valid value here — it exists solely as a field-level sentinel.
-   * Passing it will cause a {@link com.ancientprogramming.fixedformat4j.exception.FixedFormatException}
-   * to be thrown on the first {@code load} or {@code export} call.
    *
-   * @return the record-level default alignment; must be {@link Align#LEFT} or {@link Align#RIGHT}
+   * @return the record-level default alignment
    * @since 1.7.1
    */
-  Align align() default Align.LEFT;
+  RecordAlign align() default RecordAlign.LEFT;
 }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/RecordAlign.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/RecordAlign.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2004 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ancientprogramming.fixedformat4j.annotation;
+
+/**
+ * Record-level alignment choices for {@link Record#align()}.
+ *
+ * <p>Unlike {@link Align}, this enum contains only the two meaningful values for a record:
+ * {@link #LEFT} and {@link #RIGHT}. The {@code INHERIT} sentinel from {@link Align} has no
+ * meaning at the record level and is therefore absent here, making misconfiguration
+ * impossible at compile time.
+ *
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
+ * @since 1.8.0
+ */
+public enum RecordAlign {
+
+  /**
+   * Pad or chop data to the right so the text is aligned to the left.
+   * This is the default for {@link Record#align()}.
+   */
+  LEFT,
+
+  /**
+   * Pad or chop data to the left so the text is aligned to the right.
+   */
+  RIGHT
+}

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
@@ -15,7 +15,6 @@
  */
 package com.ancientprogramming.fixedformat4j.format.impl;
 
-import com.ancientprogramming.fixedformat4j.annotation.Align;
 import com.ancientprogramming.fixedformat4j.annotation.EnumFormat;
 import com.ancientprogramming.fixedformat4j.annotation.Field;
 import com.ancientprogramming.fixedformat4j.annotation.FixedFormatEnum;
@@ -265,11 +264,6 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
     Record recordAnno = fixedFormatRecordClass.getAnnotation(Record.class);
     if (recordAnno == null) {
       throw new FixedFormatException(format("%s has to be marked with the record annotation to be loaded", fixedFormatRecordClass.getName()));
-    }
-    if (recordAnno.align() == Align.INHERIT) {
-      throw new FixedFormatException(format(
-          "@Record(align) on %s must not be Align.INHERIT; use Align.LEFT or Align.RIGHT",
-          fixedFormatRecordClass.getName()));
     }
     return recordAnno;
   }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FormatInstructionsBuilder.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FormatInstructionsBuilder.java
@@ -2,6 +2,7 @@ package com.ancientprogramming.fixedformat4j.format.impl;
 
 import com.ancientprogramming.fixedformat4j.annotation.Align;
 import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.RecordAlign;
 import com.ancientprogramming.fixedformat4j.annotation.FixedFormatBoolean;
 import com.ancientprogramming.fixedformat4j.annotation.FixedFormatDecimal;
 import com.ancientprogramming.fixedformat4j.annotation.FixedFormatEnum;
@@ -48,7 +49,10 @@ class FormatInstructionsBuilder {
       return fieldAlign;
     }
     Record recordAnno = declaringClass.getAnnotation(Record.class);
-    return (recordAnno != null) ? recordAnno.align() : Align.LEFT;
+    if (recordAnno == null) {
+      return Align.LEFT;
+    }
+    return recordAnno.align() == RecordAlign.RIGHT ? Align.RIGHT : Align.LEFT;
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestFormatInstructionsBuilder.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestFormatInstructionsBuilder.java
@@ -2,6 +2,7 @@ package com.ancientprogramming.fixedformat4j.format.impl;
 
 import com.ancientprogramming.fixedformat4j.annotation.Align;
 import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.RecordAlign;
 import com.ancientprogramming.fixedformat4j.annotation.FixedFormatBoolean;
 import com.ancientprogramming.fixedformat4j.annotation.FixedFormatDecimal;
 import com.ancientprogramming.fixedformat4j.annotation.FixedFormatNumber;
@@ -164,14 +165,14 @@ public class TestFormatInstructionsBuilder {
     public String fetch() { return null; }
   }
 
-  @Record(align = Align.RIGHT)
+  @Record(align = RecordAlign.RIGHT)
   static class RightAlignRecord {
     @Field(offset = 1, length = 5)
     public String getValue() { return null; }
     public void setValue(String v) {}
   }
 
-  @Record(align = Align.RIGHT)
+  @Record(align = RecordAlign.RIGHT)
   static class OverrideAlignRecord {
     @Field(offset = 1, length = 5, align = Align.LEFT)
     public String getValue() { return null; }

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/issues/TestIssue30.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/issues/TestIssue30.java
@@ -18,15 +18,12 @@ package com.ancientprogramming.fixedformat4j.issues;
 import com.ancientprogramming.fixedformat4j.annotation.Align;
 import com.ancientprogramming.fixedformat4j.annotation.Field;
 import com.ancientprogramming.fixedformat4j.annotation.Record;
+import com.ancientprogramming.fixedformat4j.annotation.RecordAlign;
 import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
 import com.ancientprogramming.fixedformat4j.format.impl.FixedFormatManagerImpl;
 import org.junit.jupiter.api.Test;
 
-import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verifies Issue 30 — record-level default alignment via {@link Record#align()}.
@@ -115,13 +112,13 @@ public class TestIssue30 {
   // ---------------------------------------------------------------------------
 
   /**
-   * Two integer fields both inheriting {@code Align.RIGHT} from the record.
+   * Two integer fields both inheriting {@code RecordAlign.RIGHT} from the record.
    * <pre>
    * offset 1, len 5  Integer  paddingChar='0'  (inherits RIGHT from @Record)
    * offset 6, len 5  Integer  paddingChar='0'  (inherits RIGHT from @Record)
    * </pre>
    */
-  @Record(length = 10, align = Align.RIGHT)
+  @Record(length = 10, align = RecordAlign.RIGHT)
   public static class DefaultAlignRecord30 {
 
     private Integer first;
@@ -143,7 +140,7 @@ public class TestIssue30 {
    * offset 6, len 5  String   paddingChar=' '  explicit align=LEFT
    * </pre>
    */
-  @Record(length = 10, align = Align.RIGHT)
+  @Record(length = 10, align = RecordAlign.RIGHT)
   public static class MixedAlignRecord30 {
 
     private Integer number;
@@ -156,41 +153,6 @@ public class TestIssue30 {
     @Field(offset = 6, length = 5, align = Align.LEFT)
     public String getLabel() { return label; }
     public void setLabel(String label) { this.label = label; }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Validation: Align.INHERIT is rejected on @Record
-  // ---------------------------------------------------------------------------
-
-  @Test
-  public void load_recordAlignInherit_throwsFixedFormatException() {
-    FixedFormatException ex = assertThrows(FixedFormatException.class,
-        () -> manager.load(InheritAlignRecord30.class, "hello"));
-    assertTrue(ex.getMessage().contains("InheritAlignRecord30"),
-        "Exception message should contain the class name");
-  }
-
-  @Test
-  public void export_recordAlignInherit_throwsFixedFormatException() {
-    InheritAlignRecord30 record = new InheritAlignRecord30();
-    record.setValue("hello");
-    FixedFormatException ex = assertThrows(FixedFormatException.class,
-        () -> manager.export(record));
-    assertTrue(ex.getMessage().contains("InheritAlignRecord30"),
-        "Exception message should contain the class name");
-  }
-
-  /**
-   * Misconfigured record — {@code Align.INHERIT} is not valid at record level.
-   */
-  @Record(length = 5, align = Align.INHERIT)
-  public static class InheritAlignRecord30 {
-
-    private String value;
-
-    @Field(offset = 1, length = 5)
-    public String getValue() { return value; }
-    public void setValue(String value) { this.value = value; }
   }
 
   /**


### PR DESCRIPTION
Introduces `RecordAlign { LEFT, RIGHT }` as the type of `@Record#align()`, replacing `Align`. This makes passing `Align.INHERIT` at the record level impossible at compile time, removing the runtime guard added in 1.7.1.

Breaking change: `@Record(align = Align.LEFT/RIGHT)` must be updated to `@Record(align = RecordAlign.LEFT/RIGHT)`.

Closes #81

Generated with [Claude Code](https://claude.ai/code)