### PR TITLE
test: first-wave mutation coverage lift targeting ~83% (issue #105)

### DIFF
--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/data/TestFixedFormatBooleanData.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/data/TestFixedFormatBooleanData.java
@@ -1,0 +1,78 @@
+package com.ancientprogramming.fixedformat4j.format.data;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestFixedFormatBooleanData {
+
+  @Test
+  void getTrueValue_returnsConstructorArg() {
+    FixedFormatBooleanData data = new FixedFormatBooleanData("YES", "NO");
+    assertEquals("YES", data.getTrueValue());
+  }
+
+  @Test
+  void getFalseValue_returnsConstructorArg() {
+    FixedFormatBooleanData data = new FixedFormatBooleanData("YES", "NO");
+    assertEquals("NO", data.getFalseValue());
+  }
+
+  @Test
+  void getTrueValue_distinctFromFalseValue() {
+    FixedFormatBooleanData data = new FixedFormatBooleanData("T", "F");
+    assertNotEquals(data.getTrueValue(), data.getFalseValue());
+  }
+
+  @Test
+  void getTrueValue_notConfusedWithFalseValue() {
+    FixedFormatBooleanData data = new FixedFormatBooleanData("TRUE_VAL", "FALSE_VAL");
+    assertEquals("TRUE_VAL", data.getTrueValue());
+    assertEquals("FALSE_VAL", data.getFalseValue());
+  }
+
+  @Test
+  void defaultInstance_trueValueIsT() {
+    assertEquals("T", FixedFormatBooleanData.DEFAULT.getTrueValue());
+  }
+
+  @Test
+  void defaultInstance_falseValueIsF() {
+    assertEquals("F", FixedFormatBooleanData.DEFAULT.getFalseValue());
+  }
+
+  @Test
+  void toString_containsTrueValue() {
+    FixedFormatBooleanData data = new FixedFormatBooleanData("YES", "NO");
+    assertTrue(data.toString().contains("YES"),
+        "toString should contain trueValue: " + data.toString());
+  }
+
+  @Test
+  void toString_containsFalseValue() {
+    FixedFormatBooleanData data = new FixedFormatBooleanData("YES", "NO");
+    assertTrue(data.toString().contains("NO"),
+        "toString should contain falseValue: " + data.toString());
+  }
+
+  @Test
+  void toString_containsClassName() {
+    FixedFormatBooleanData data = new FixedFormatBooleanData("T", "F");
+    assertTrue(data.toString().contains("FixedFormatBooleanData"),
+        "toString should contain class name: " + data.toString());
+  }
+
+  @Test
+  void toString_containsTrueValueFieldLabel() {
+    FixedFormatBooleanData data = new FixedFormatBooleanData("T", "F");
+    assertTrue(data.toString().contains("trueValue"),
+        "toString should label trueValue: " + data.toString());
+  }
+
+  @Test
+  void toString_containsFalseValueFieldLabel() {
+    FixedFormatBooleanData data = new FixedFormatBooleanData("T", "F");
+    assertTrue(data.toString().contains("falseValue"),
+        "toString should label falseValue: " + data.toString());
+  }
+}

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/data/TestFixedFormatDecimalData.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/data/TestFixedFormatDecimalData.java
@@ -1,0 +1,104 @@
+package com.ancientprogramming.fixedformat4j.format.data;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.RoundingMode;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestFixedFormatDecimalData {
+
+  @Test
+  void getDecimals_returnsConstructorArg() {
+    FixedFormatDecimalData data = new FixedFormatDecimalData(3, true, ',', RoundingMode.HALF_UP);
+    assertEquals(3, data.getDecimals());
+  }
+
+  @Test
+  void isUseDecimalDelimiter_trueWhenPassedTrue() {
+    FixedFormatDecimalData data = new FixedFormatDecimalData(2, true, '.', RoundingMode.HALF_UP);
+    assertTrue(data.isUseDecimalDelimiter());
+  }
+
+  @Test
+  void isUseDecimalDelimiter_falseWhenPassedFalse() {
+    FixedFormatDecimalData data = new FixedFormatDecimalData(2, false, '.', RoundingMode.HALF_UP);
+    assertFalse(data.isUseDecimalDelimiter());
+  }
+
+  @Test
+  void getDecimalDelimiter_returnsConstructorArg() {
+    FixedFormatDecimalData data = new FixedFormatDecimalData(2, true, ',', RoundingMode.HALF_UP);
+    assertEquals(',', data.getDecimalDelimiter());
+  }
+
+  @Test
+  void getDecimalDelimiter_distinctForDifferentInputs() {
+    FixedFormatDecimalData dot = new FixedFormatDecimalData(2, true, '.', RoundingMode.HALF_UP);
+    FixedFormatDecimalData comma = new FixedFormatDecimalData(2, true, ',', RoundingMode.HALF_UP);
+    assertNotEquals(dot.getDecimalDelimiter(), comma.getDecimalDelimiter());
+  }
+
+  @Test
+  void getRoundingMode_returnsConstructorArg() {
+    FixedFormatDecimalData data = new FixedFormatDecimalData(2, false, '.', RoundingMode.CEILING);
+    assertEquals(RoundingMode.CEILING, data.getRoundingMode());
+  }
+
+  @Test
+  void getRoundingMode_notConfusedBetweenDifferentModes() {
+    FixedFormatDecimalData up = new FixedFormatDecimalData(2, false, '.', RoundingMode.UP);
+    FixedFormatDecimalData down = new FixedFormatDecimalData(2, false, '.', RoundingMode.DOWN);
+    assertNotEquals(up.getRoundingMode(), down.getRoundingMode());
+  }
+
+  @Test
+  void defaultInstance_hasExpectedDecimals() {
+    assertEquals(2, FixedFormatDecimalData.DEFAULT.getDecimals());
+  }
+
+  @Test
+  void defaultInstance_doesNotUseDecimalDelimiter() {
+    assertFalse(FixedFormatDecimalData.DEFAULT.isUseDecimalDelimiter());
+  }
+
+  @Test
+  void defaultInstance_delimiterIsDot() {
+    assertEquals('.', FixedFormatDecimalData.DEFAULT.getDecimalDelimiter());
+  }
+
+  @Test
+  void toString_containsDecimalsValue() {
+    FixedFormatDecimalData data = new FixedFormatDecimalData(4, true, ',', RoundingMode.HALF_UP);
+    assertTrue(data.toString().contains("4"),
+        "toString should contain decimals: " + data.toString());
+  }
+
+  @Test
+  void toString_containsDelimiterValue() {
+    FixedFormatDecimalData data = new FixedFormatDecimalData(2, true, ',', RoundingMode.HALF_UP);
+    assertTrue(data.toString().contains(","),
+        "toString should contain delimiter: " + data.toString());
+  }
+
+  @Test
+  void toString_containsRoundingMode() {
+    FixedFormatDecimalData data = new FixedFormatDecimalData(2, false, '.', RoundingMode.FLOOR);
+    assertTrue(data.toString().contains("FLOOR"),
+        "toString should contain rounding mode: " + data.toString());
+  }
+
+  @Test
+  void toString_containsUseDecimalDelimiterValue() {
+    FixedFormatDecimalData data = new FixedFormatDecimalData(2, true, '.', RoundingMode.HALF_UP);
+    assertTrue(data.toString().contains("true"),
+        "toString should contain useDecimalDelimiter: " + data.toString());
+  }
+
+  @Test
+  void toString_containsClassName() {
+    FixedFormatDecimalData data = new FixedFormatDecimalData(2, false, '.', RoundingMode.HALF_UP);
+    assertTrue(data.toString().contains("FixedFormatDecimalData"),
+        "toString should contain class name: " + data.toString());
+  }
+}

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/data/TestFixedFormatEnumData.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/data/TestFixedFormatEnumData.java
@@ -1,0 +1,61 @@
+package com.ancientprogramming.fixedformat4j.format.data;
+
+import com.ancientprogramming.fixedformat4j.annotation.EnumFormat;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestFixedFormatEnumData {
+
+  @Test
+  void getEnumFormat_returnsLiteralWhenPassedLiteral() {
+    FixedFormatEnumData data = new FixedFormatEnumData(EnumFormat.LITERAL);
+    assertEquals(EnumFormat.LITERAL, data.getEnumFormat());
+  }
+
+  @Test
+  void getEnumFormat_returnsNumericWhenPassedNumeric() {
+    FixedFormatEnumData data = new FixedFormatEnumData(EnumFormat.NUMERIC);
+    assertEquals(EnumFormat.NUMERIC, data.getEnumFormat());
+  }
+
+  @Test
+  void getEnumFormat_literalAndNumericAreDistinct() {
+    FixedFormatEnumData literal = new FixedFormatEnumData(EnumFormat.LITERAL);
+    FixedFormatEnumData numeric = new FixedFormatEnumData(EnumFormat.NUMERIC);
+    assertNotEquals(literal.getEnumFormat(), numeric.getEnumFormat());
+  }
+
+  @Test
+  void defaultInstance_isLiteral() {
+    assertEquals(EnumFormat.LITERAL, FixedFormatEnumData.DEFAULT.getEnumFormat());
+  }
+
+  @Test
+  void toString_containsEnumFormatValue_literal() {
+    FixedFormatEnumData data = new FixedFormatEnumData(EnumFormat.LITERAL);
+    assertTrue(data.toString().contains("LITERAL"),
+        "toString should contain LITERAL: " + data.toString());
+  }
+
+  @Test
+  void toString_containsEnumFormatValue_numeric() {
+    FixedFormatEnumData data = new FixedFormatEnumData(EnumFormat.NUMERIC);
+    assertTrue(data.toString().contains("NUMERIC"),
+        "toString should contain NUMERIC: " + data.toString());
+  }
+
+  @Test
+  void toString_containsClassName() {
+    FixedFormatEnumData data = new FixedFormatEnumData(EnumFormat.LITERAL);
+    assertTrue(data.toString().contains("FixedFormatEnumData"),
+        "toString should contain class name: " + data.toString());
+  }
+
+  @Test
+  void toString_containsFieldLabel() {
+    FixedFormatEnumData data = new FixedFormatEnumData(EnumFormat.LITERAL);
+    assertTrue(data.toString().contains("enumFormat"),
+        "toString should label the enumFormat field: " + data.toString());
+  }
+}

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/data/TestFixedFormatNumberData.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/data/TestFixedFormatNumberData.java
@@ -1,0 +1,95 @@
+package com.ancientprogramming.fixedformat4j.format.data;
+
+import com.ancientprogramming.fixedformat4j.annotation.Sign;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestFixedFormatNumberData {
+
+  @Test
+  void getSigning_returnsConstructorArg_nosign() {
+    FixedFormatNumberData data = new FixedFormatNumberData(Sign.NOSIGN, '+', '-');
+    assertEquals(Sign.NOSIGN, data.getSigning());
+  }
+
+  @Test
+  void getSigning_returnsConstructorArg_prepend() {
+    FixedFormatNumberData data = new FixedFormatNumberData(Sign.PREPEND, '+', '-');
+    assertEquals(Sign.PREPEND, data.getSigning());
+  }
+
+  @Test
+  void getSigning_returnsConstructorArg_append() {
+    FixedFormatNumberData data = new FixedFormatNumberData(Sign.APPEND, '+', '-');
+    assertEquals(Sign.APPEND, data.getSigning());
+  }
+
+  @Test
+  void getPositiveSign_returnsConstructorArg() {
+    FixedFormatNumberData data = new FixedFormatNumberData(Sign.PREPEND, '+', '-');
+    assertEquals('+', (char) data.getPositiveSign());
+  }
+
+  @Test
+  void getNegativeSign_returnsConstructorArg() {
+    FixedFormatNumberData data = new FixedFormatNumberData(Sign.PREPEND, '+', '-');
+    assertEquals('-', (char) data.getNegativeSign());
+  }
+
+  @Test
+  void positiveAndNegativeSigns_areDistinct() {
+    FixedFormatNumberData data = new FixedFormatNumberData(Sign.PREPEND, '+', '-');
+    assertNotEquals((char) data.getPositiveSign(), (char) data.getNegativeSign());
+  }
+
+  @Test
+  void positiveSign_notConfusedWithNegativeSign() {
+    FixedFormatNumberData data = new FixedFormatNumberData(Sign.APPEND, 'P', 'N');
+    assertEquals('P', (char) data.getPositiveSign());
+    assertEquals('N', (char) data.getNegativeSign());
+  }
+
+  @Test
+  void defaultInstance_signingIsNoSign() {
+    assertEquals(Sign.NOSIGN, FixedFormatNumberData.DEFAULT.getSigning());
+  }
+
+  @Test
+  void defaultInstance_positiveSignIsPlus() {
+    assertEquals('+', (char) FixedFormatNumberData.DEFAULT.getPositiveSign());
+  }
+
+  @Test
+  void defaultInstance_negativeSignIsMinus() {
+    assertEquals('-', (char) FixedFormatNumberData.DEFAULT.getNegativeSign());
+  }
+
+  @Test
+  void toString_containsSigningValue() {
+    FixedFormatNumberData data = new FixedFormatNumberData(Sign.PREPEND, '+', '-');
+    assertTrue(data.toString().contains("PREPEND"),
+        "toString should contain signing: " + data.toString());
+  }
+
+  @Test
+  void toString_containsPositiveSign() {
+    FixedFormatNumberData data = new FixedFormatNumberData(Sign.NOSIGN, '+', '-');
+    assertTrue(data.toString().contains("+"),
+        "toString should contain positiveSign: " + data.toString());
+  }
+
+  @Test
+  void toString_containsNegativeSign() {
+    FixedFormatNumberData data = new FixedFormatNumberData(Sign.NOSIGN, '+', '-');
+    assertTrue(data.toString().contains("-"),
+        "toString should contain negativeSign: " + data.toString());
+  }
+
+  @Test
+  void toString_containsClassName() {
+    FixedFormatNumberData data = new FixedFormatNumberData(Sign.NOSIGN, '+', '-');
+    assertTrue(data.toString().contains("FixedFormatNumberData"),
+        "toString should contain class name: " + data.toString());
+  }
+}

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/data/TestFixedFormatPatternData.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/data/TestFixedFormatPatternData.java
@@ -1,0 +1,81 @@
+package com.ancientprogramming.fixedformat4j.format.data;
+
+import com.ancientprogramming.fixedformat4j.annotation.FixedFormatPattern;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestFixedFormatPatternData {
+
+  @Test
+  void getPattern_returnsConstructorArg() {
+    FixedFormatPatternData data = new FixedFormatPatternData("yyyyMMdd");
+    assertEquals("yyyyMMdd", data.getPattern());
+  }
+
+  @Test
+  void getPattern_distinctForDifferentPatterns() {
+    FixedFormatPatternData date = new FixedFormatPatternData("yyyyMMdd");
+    FixedFormatPatternData datetime = new FixedFormatPatternData("yyyy-MM-dd'T'HH:mm:ss");
+    assertNotEquals(date.getPattern(), datetime.getPattern());
+  }
+
+  @Test
+  void getPattern_exactlyMatchesInput() {
+    String pattern = "dd/MM/yyyy HH:mm";
+    assertEquals(pattern, new FixedFormatPatternData(pattern).getPattern());
+  }
+
+  @Test
+  void defaultInstance_pattern_matchesDatePattern() {
+    assertEquals(FixedFormatPattern.DATE_PATTERN, FixedFormatPatternData.DEFAULT.getPattern());
+  }
+
+  @Test
+  void localDateDefaultInstance_pattern_matchesLocalDatePattern() {
+    assertEquals(FixedFormatPattern.LOCALDATE_PATTERN, FixedFormatPatternData.LOCALDATE_DEFAULT.getPattern());
+  }
+
+  @Test
+  void datetimeDefaultInstance_pattern_matchesDatetimePattern() {
+    assertEquals(FixedFormatPattern.DATETIME_PATTERN, FixedFormatPatternData.DATETIME_DEFAULT.getPattern());
+  }
+
+  @Test
+  void threeDefaults_haveDistinctPatterns() {
+    assertNotEquals(FixedFormatPatternData.DEFAULT.getPattern(),
+        FixedFormatPatternData.LOCALDATE_DEFAULT.getPattern());
+    assertNotEquals(FixedFormatPatternData.DEFAULT.getPattern(),
+        FixedFormatPatternData.DATETIME_DEFAULT.getPattern());
+    assertNotEquals(FixedFormatPatternData.LOCALDATE_DEFAULT.getPattern(),
+        FixedFormatPatternData.DATETIME_DEFAULT.getPattern());
+  }
+
+  @Test
+  void toString_containsPattern() {
+    FixedFormatPatternData data = new FixedFormatPatternData("yyyyMMdd");
+    assertTrue(data.toString().contains("yyyyMMdd"),
+        "toString should contain pattern: " + data.toString());
+  }
+
+  @Test
+  void toString_containsClassName() {
+    FixedFormatPatternData data = new FixedFormatPatternData("yyyyMMdd");
+    assertTrue(data.toString().contains("FixedFormatPatternData"),
+        "toString should contain class name: " + data.toString());
+  }
+
+  @Test
+  void toString_containsPatternFieldLabel() {
+    FixedFormatPatternData data = new FixedFormatPatternData("yyyyMMdd");
+    assertTrue(data.toString().contains("pattern"),
+        "toString should label the pattern field: " + data.toString());
+  }
+
+  @Test
+  void toString_distinctForDifferentPatterns() {
+    FixedFormatPatternData a = new FixedFormatPatternData("yyyyMMdd");
+    FixedFormatPatternData b = new FixedFormatPatternData("ddMMyyyy");
+    assertNotEquals(a.toString(), b.toString());
+  }
+}

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestByTypeFormatter.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestByTypeFormatter.java
@@ -1,11 +1,13 @@
 package com.ancientprogramming.fixedformat4j.format.impl;
 
 import com.ancientprogramming.fixedformat4j.annotation.Align;
+import com.ancientprogramming.fixedformat4j.annotation.EnumFormat;
 import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
 import com.ancientprogramming.fixedformat4j.format.FormatContext;
 import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
 import com.ancientprogramming.fixedformat4j.format.data.FixedFormatBooleanData;
 import com.ancientprogramming.fixedformat4j.format.data.FixedFormatDecimalData;
+import com.ancientprogramming.fixedformat4j.format.data.FixedFormatEnumData;
 import com.ancientprogramming.fixedformat4j.format.data.FixedFormatNumberData;
 import com.ancientprogramming.fixedformat4j.format.data.FixedFormatPatternData;
 import org.junit.jupiter.api.Test;
@@ -23,6 +25,8 @@ import static org.junit.jupiter.api.Assertions.*;
  * Tests ByTypeFormatter dispatch to each known type formatter.
  */
 public class TestByTypeFormatter {
+
+  enum Season { SPRING, SUMMER, AUTUMN, WINTER }
 
   private ByTypeFormatter formatterFor(Class<?> type) {
     return new ByTypeFormatter(new FormatContext(1, type, ByTypeFormatter.class));
@@ -181,5 +185,103 @@ public class TestByTypeFormatter {
     ByTypeFormatter f = formatterFor(UUID.class);
     FormatInstructions instr = strInstr(36);
     assertThrows(FixedFormatException.class, () -> f.parse("some-uuid-string--------------------", instr));
+  }
+
+  @Test
+  public void testUnknownTypeExceptionMessageContainsTypeName() {
+    ByTypeFormatter f = formatterFor(UUID.class);
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> f.parse("some-uuid-string--------------------", strInstr(36)));
+    assertTrue(ex.getMessage().contains("UUID"),
+        "exception message should name the unsupported type: " + ex.getMessage());
+  }
+
+  // --- Format assertions (so type-swap mutations die) ---
+
+  @Test
+  public void testIntegerFormatterFormat() {
+    ByTypeFormatter f = formatterFor(Integer.class);
+    assertEquals("00042", f.format(42, numInstr(5)));
+  }
+
+  @Test
+  public void testLongFormatterFormat() {
+    ByTypeFormatter f = formatterFor(Long.class);
+    assertEquals("0000000123", f.format(123L, numInstr(10)));
+  }
+
+  @Test
+  public void testShortFormatterFormat() {
+    ByTypeFormatter f = formatterFor(Short.class);
+    assertEquals("00003", f.format((short) 3, numInstr(5)));
+  }
+
+  @Test
+  public void testBooleanFormatterFormat() {
+    ByTypeFormatter f = formatterFor(Boolean.class);
+    FormatInstructions instr = new FormatInstructions(1, Align.LEFT, ' ', null,
+        new FixedFormatBooleanData("T", "F"), null, null);
+    assertEquals("T", f.format(true, instr));
+    assertEquals("F", f.format(false, instr));
+  }
+
+  @Test
+  public void testCharacterFormatterFormat() {
+    ByTypeFormatter f = formatterFor(Character.class);
+    FormatInstructions instr = new FormatInstructions(1, Align.LEFT, ' ', null, null, null, null);
+    assertEquals("X", f.format('X', instr));
+  }
+
+  @Test
+  public void testDoubleFormatterFormat() {
+    ByTypeFormatter f = formatterFor(Double.class);
+    FormatInstructions instr = new FormatInstructions(5, Align.RIGHT, '0', null, null,
+        FixedFormatNumberData.DEFAULT,
+        new FixedFormatDecimalData(2, false, '.', RoundingMode.UNNECESSARY));
+    assertEquals("00123", f.format(1.23, instr));
+  }
+
+  @Test
+  public void testBigDecimalFormatterFormat() {
+    ByTypeFormatter f = formatterFor(BigDecimal.class);
+    FormatInstructions instr = new FormatInstructions(5, Align.RIGHT, '0', null, null,
+        FixedFormatNumberData.DEFAULT,
+        new FixedFormatDecimalData(2, false, '.', RoundingMode.UNNECESSARY));
+    assertEquals("00123", f.format(new BigDecimal("1.23"), instr));
+  }
+
+  // --- Enum dispatch ---
+
+  @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public void testDispatchesToEnumFormatter_parse() {
+    ByTypeFormatter f = new ByTypeFormatter(new FormatContext(1, Season.class, ByTypeFormatter.class));
+    FormatInstructions instr = new FormatInstructions(10, Align.LEFT, ' ', null, null, null, null,
+        new FixedFormatEnumData(EnumFormat.LITERAL));
+    assertEquals(Season.SUMMER, f.parse("SUMMER    ", instr));
+  }
+
+  @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public void testDispatchesToEnumFormatter_format() {
+    ByTypeFormatter f = new ByTypeFormatter(new FormatContext(1, Season.class, ByTypeFormatter.class));
+    FormatInstructions instr = new FormatInstructions(10, Align.LEFT, ' ', null, null, null, null,
+        new FixedFormatEnumData(EnumFormat.LITERAL));
+    assertEquals("WINTER    ", f.format(Season.WINTER, instr));
+  }
+
+  @Test
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public void testEnumTypeRoutesToEnumFormatter() {
+    ByTypeFormatter f = new ByTypeFormatter(new FormatContext(1, Season.class, ByTypeFormatter.class));
+    assertTrue(f.actualFormatter(Season.class) instanceof EnumFormatter,
+        "enum type should route to EnumFormatter");
+  }
+
+  @Test
+  public void testStringTypeRoutesToStringFormatter() {
+    ByTypeFormatter f = formatterFor(String.class);
+    assertTrue(f.actualFormatter(String.class) instanceof StringFormatter,
+        "String type should route to StringFormatter");
   }
 }

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestDateFormatter.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestDateFormatter.java
@@ -16,6 +16,7 @@
 package com.ancientprogramming.fixedformat4j.format.impl;
 
 import com.ancientprogramming.fixedformat4j.annotation.Align;
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
 import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
 import com.ancientprogramming.fixedformat4j.format.FixedFormatter;
 import com.ancientprogramming.fixedformat4j.format.data.FixedFormatPatternData;
@@ -98,6 +99,45 @@ public class TestDateFormatter {
     Date original = getDateTime(2012, 9, 12, 11, 11, 0);
     String formatted = formatter.format(original, instr);
     assertEquals(original, formatter.parse(formatted, instr));
+  }
+
+  @Test
+  public void testInvalidDateStringThrowsFixedFormatExceptionWithMessage() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class, () ->
+        formatter.parse("NOTADATE", new FormatInstructions(8, Align.LEFT, ' ',
+            new FixedFormatPatternData("yyyyMMdd"), null, null, null)));
+    assertTrue(ex.getMessage().contains("NOTADATE"),
+        "message should contain the bad input: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains("yyyyMMdd"),
+        "message should contain the pattern: " + ex.getMessage());
+  }
+
+  @Test
+  public void testNonSpacePaddingChar_leftAlign_roundTrip() {
+    FormatInstructions instr = new FormatInstructions(12, Align.LEFT, '*',
+        new FixedFormatPatternData("yyyyMMdd"), null, null, null);
+    Date original = getDate(2026, 4, 15);
+    String formatted = formatter.format(original, instr);
+    assertEquals("20260415****", formatted);
+    assertEquals(original, formatter.parse(formatted, instr));
+  }
+
+  @Test
+  public void testNonSpacePaddingChar_rightAlign_roundTrip() {
+    FormatInstructions instr = new FormatInstructions(12, Align.RIGHT, '*',
+        new FixedFormatPatternData("yyyyMMdd"), null, null, null);
+    Date original = getDate(2026, 4, 15);
+    String formatted = formatter.format(original, instr);
+    assertEquals("****20260415", formatted);
+    assertEquals(original, formatter.parse(formatted, instr));
+  }
+
+  @Test
+  public void testRoundTripWithNonZeroDateComponents() {
+    FormatInstructions instr = new FormatInstructions(14, Align.LEFT, '0',
+        new FixedFormatPatternData("yyyyMMddHHmmss"), null, null, null);
+    Date original = getDateTime(2026, 4, 15, 13, 45, 22);
+    assertEquals(original, formatter.parse(formatter.format(original, instr), instr));
   }
 
   public Date getDate(int year, int month, int day) {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestEnumFormatter.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestEnumFormatter.java
@@ -1,0 +1,248 @@
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.annotation.Align;
+import com.ancientprogramming.fixedformat4j.annotation.EnumFormat;
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+import com.ancientprogramming.fixedformat4j.format.FormatContext;
+import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
+import com.ancientprogramming.fixedformat4j.format.data.FixedFormatEnumData;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestEnumFormatter {
+
+  enum Color { RED, GREEN, BLUE }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private final FormatContext<Color> colorContext =
+      new FormatContext(1, Color.class, ByTypeFormatter.class);
+  private final EnumFormatter formatter = new EnumFormatter(colorContext);
+
+  private FormatInstructions literalInstr(int len) {
+    return new FormatInstructions(len, Align.LEFT, ' ', null, null, null, null,
+        new FixedFormatEnumData(EnumFormat.LITERAL));
+  }
+
+  private FormatInstructions numericInstr(int len) {
+    return new FormatInstructions(len, Align.LEFT, ' ', null, null, null, null,
+        new FixedFormatEnumData(EnumFormat.NUMERIC));
+  }
+
+  // --- LITERAL mode: parse ---
+
+  @Test
+  void literalParse_returnsRedConstant() {
+    assertEquals(Color.RED, formatter.parse("RED       ", literalInstr(10)));
+  }
+
+  @Test
+  void literalParse_returnsGreenConstant() {
+    assertEquals(Color.GREEN, formatter.parse("GREEN     ", literalInstr(10)));
+  }
+
+  @Test
+  void literalParse_returnsBlueConstant() {
+    assertEquals(Color.BLUE, formatter.parse("BLUE      ", literalInstr(10)));
+  }
+
+  // --- LITERAL mode: format ---
+
+  @Test
+  void literalFormat_redProducesRedString() {
+    assertEquals("RED       ", formatter.format(Color.RED, literalInstr(10)));
+  }
+
+  @Test
+  void literalFormat_greenProducesGreenString() {
+    assertEquals("GREEN     ", formatter.format(Color.GREEN, literalInstr(10)));
+  }
+
+  @Test
+  void literalFormat_blueProducesBlueString() {
+    assertEquals("BLUE      ", formatter.format(Color.BLUE, literalInstr(10)));
+  }
+
+  // --- LITERAL round-trip ---
+
+  @Test
+  void literalRoundTrip_allConstants() {
+    FormatInstructions instr = literalInstr(10);
+    for (Color c : Color.values()) {
+      assertEquals(c, formatter.parse(formatter.format(c, instr), instr),
+          "round-trip failed for " + c);
+    }
+  }
+
+  // --- NUMERIC mode: parse ---
+
+  @Test
+  void numericParse_ordinalZeroIsRed() {
+    assertEquals(Color.RED, formatter.parse("0  ", numericInstr(3)));
+  }
+
+  @Test
+  void numericParse_ordinalOneIsGreen() {
+    assertEquals(Color.GREEN, formatter.parse("1  ", numericInstr(3)));
+  }
+
+  @Test
+  void numericParse_ordinalTwoIsBlue() {
+    assertEquals(Color.BLUE, formatter.parse("2  ", numericInstr(3)));
+  }
+
+  // --- NUMERIC mode: format ---
+
+  @Test
+  void numericFormat_redIsOrdinalZero() {
+    assertEquals("0  ", formatter.format(Color.RED, numericInstr(3)));
+  }
+
+  @Test
+  void numericFormat_greenIsOrdinalOne() {
+    assertEquals("1  ", formatter.format(Color.GREEN, numericInstr(3)));
+  }
+
+  @Test
+  void numericFormat_blueIsOrdinalTwo() {
+    assertEquals("2  ", formatter.format(Color.BLUE, numericInstr(3)));
+  }
+
+  // --- NUMERIC round-trip ---
+
+  @Test
+  void numericRoundTrip_allConstants() {
+    FormatInstructions instr = numericInstr(3);
+    for (Color c : Color.values()) {
+      assertEquals(c, formatter.parse(formatter.format(c, instr), instr),
+          "numeric round-trip failed for " + c);
+    }
+  }
+
+  // --- LITERAL vs NUMERIC produce distinct output ---
+
+  @Test
+  void literalAndNumericProduceDistinctOutput() {
+    assertNotEquals(
+        formatter.format(Color.RED, literalInstr(5)),
+        formatter.format(Color.RED, numericInstr(5)),
+        "LITERAL and NUMERIC should produce different strings for the same value");
+  }
+
+  // --- Null / empty handling ---
+
+  @Test
+  void allPaddingInput_literal_parsesToNull() {
+    assertNull(formatter.parse("          ", literalInstr(10)));
+  }
+
+  @Test
+  void allPaddingInput_numeric_parsesToNull() {
+    assertNull(formatter.parse("   ", numericInstr(3)));
+  }
+
+  @Test
+  void nullValue_literal_formatsToAllPadding() {
+    assertEquals("          ", formatter.format(null, literalInstr(10)));
+  }
+
+  @Test
+  void nullValue_numeric_formatsToAllPadding() {
+    assertEquals("   ", formatter.format(null, numericInstr(3)));
+  }
+
+  // --- Right-alignment padding ---
+
+  @Test
+  void rightAlignedLiteralParse_stripsLeadingSpaces() {
+    FormatInstructions instr = new FormatInstructions(10, Align.RIGHT, ' ', null, null, null, null,
+        new FixedFormatEnumData(EnumFormat.LITERAL));
+    assertEquals(Color.RED, formatter.parse("       RED", instr));
+  }
+
+  @Test
+  void rightAlignedNumericParse_stripsLeadingSpaces() {
+    FormatInstructions instr = new FormatInstructions(5, Align.RIGHT, ' ', null, null, null, null,
+        new FixedFormatEnumData(EnumFormat.NUMERIC));
+    assertEquals(Color.BLUE, formatter.parse("    2", instr));
+  }
+
+  // --- Error paths ---
+
+  @Test
+  void unknownLiteralName_throwsFixedFormatException() {
+    assertThrows(FixedFormatException.class,
+        () -> formatter.parse("PURPLE    ", literalInstr(10)));
+  }
+
+  @Test
+  void unknownLiteralName_exceptionMessageContainsBadValue() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> formatter.parse("PURPLE    ", literalInstr(10)));
+    assertTrue(ex.getMessage().contains("PURPLE"),
+        "message should contain the bad value: " + ex.getMessage());
+  }
+
+  @Test
+  void unknownLiteralName_exceptionMessageContainsEnumClassName() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> formatter.parse("PURPLE    ", literalInstr(10)));
+    assertTrue(ex.getMessage().contains(Color.class.getName()),
+        "message should contain the enum class name: " + ex.getMessage());
+  }
+
+  @Test
+  void outOfRangeOrdinal_positive_throwsFixedFormatException() {
+    assertThrows(FixedFormatException.class,
+        () -> formatter.asObject("99", numericInstr(3)));
+  }
+
+  @Test
+  void outOfRangeOrdinal_positive_exceptionMessageMentionsOutOfRange() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> formatter.asObject("99", numericInstr(3)));
+    assertTrue(ex.getMessage().contains("out of range"),
+        "message should mention out of range: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains("99"),
+        "message should contain the bad ordinal: " + ex.getMessage());
+  }
+
+  @Test
+  void outOfRangeOrdinal_negative_exceptionMessageMentionsOutOfRange() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> formatter.asObject("-1", numericInstr(3)));
+    assertTrue(ex.getMessage().contains("out of range"),
+        "message should mention out of range: " + ex.getMessage());
+  }
+
+  @Test
+  void nonNumericOrdinal_throwsFixedFormatException() {
+    assertThrows(FixedFormatException.class,
+        () -> formatter.asObject("XYZ", numericInstr(3)));
+  }
+
+  @Test
+  void nonNumericOrdinal_exceptionMessageMentionsCannotParseOrdinal() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> formatter.asObject("XYZ", numericInstr(3)));
+    assertTrue(ex.getMessage().contains("Cannot parse ordinal"),
+        "message should mention parse failure: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains(Color.class.getName()),
+        "message should contain enum class: " + ex.getMessage());
+  }
+
+  // --- Default enum data (null → LITERAL) ---
+
+  @Test
+  void nullEnumData_defaultsToLiteralBehavior_parse() {
+    // 7-arg constructor uses FixedFormatEnumData.DEFAULT (LITERAL)
+    FormatInstructions instr = new FormatInstructions(10, Align.LEFT, ' ', null, null, null, null);
+    assertEquals(Color.BLUE, formatter.parse("BLUE      ", instr));
+  }
+
+  @Test
+  void nullEnumData_defaultsToLiteralBehavior_format() {
+    FormatInstructions instr = new FormatInstructions(10, Align.LEFT, ' ', null, null, null, null);
+    assertEquals("GREEN     ", formatter.format(Color.GREEN, instr));
+  }
+}

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestLocalDateFormatter.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestLocalDateFormatter.java
@@ -176,6 +176,54 @@ public class TestLocalDateFormatter {
     assertEquals(original, formatter.parse(formatted, instr));
   }
 
+  // --- Message assertions for exception paths ---
+
+  @Test
+  public void testInvalidDateStringExceptionContainsBadInput() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class, () ->
+        formatter.parse("NOTADATE", instructions(8, "yyyyMMdd")));
+    assertTrue(ex.getMessage().contains("NOTADATE"),
+        "message should contain bad input: " + ex.getMessage());
+  }
+
+  @Test
+  public void testInvalidDateStringExceptionContainsPattern() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class, () ->
+        formatter.parse("NOTADATE", instructions(8, "yyyyMMdd")));
+    assertTrue(ex.getMessage().contains("yyyyMMdd"),
+        "message should contain pattern: " + ex.getMessage());
+  }
+
+  @Test
+  public void testInvalidDateStringExceptionContainsTypeName() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class, () ->
+        formatter.parse("NOTADATE", instructions(8, "yyyyMMdd")));
+    assertTrue(ex.getMessage().contains(LocalDate.class.getName()),
+        "message should contain type name: " + ex.getMessage());
+  }
+
+  // --- Non-space padding char ---
+
+  @Test
+  public void testStarPaddingChar_leftAlign_roundTrip() {
+    FormatInstructions instr = new FormatInstructions(12, Align.LEFT, '*',
+        new FixedFormatPatternData("yyyyMMdd"), null, null, null);
+    LocalDate original = LocalDate.of(2026, 4, 15);
+    String formatted = formatter.format(original, instr);
+    assertEquals("20260415****", formatted);
+    assertEquals(original, formatter.parse(formatted, instr));
+  }
+
+  @Test
+  public void testStarPaddingChar_rightAlign_roundTrip() {
+    FormatInstructions instr = new FormatInstructions(12, Align.RIGHT, '*',
+        new FixedFormatPatternData("yyyyMMdd"), null, null, null);
+    LocalDate original = LocalDate.of(2026, 4, 15);
+    String formatted = formatter.format(original, instr);
+    assertEquals("****20260415", formatted);
+    assertEquals(original, formatter.parse(formatted, instr));
+  }
+
   // --- Concurrency ---
 
   @Test

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestLocalDateTimeFormatter.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestLocalDateTimeFormatter.java
@@ -135,6 +135,54 @@ public class TestLocalDateTimeFormatter {
     );
   }
 
+  // --- Message assertions for exception paths ---
+
+  @Test
+  public void testInvalidDateTimeStringExceptionContainsPattern() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class, () ->
+        formatter.parse("NOT-A-DATE-------T-", instructions(19, "yyyy-MM-dd'T'HH:mm:ss")));
+    assertTrue(ex.getMessage().contains("yyyy-MM-dd"),
+        "message should contain pattern: " + ex.getMessage());
+  }
+
+  @Test
+  public void testInvalidDateTimeStringExceptionContainsTypeName() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class, () ->
+        formatter.parse("NOT-A-DATE-------T-", instructions(19, "yyyy-MM-dd'T'HH:mm:ss")));
+    assertTrue(ex.getMessage().contains(LocalDateTime.class.getName()),
+        "message should contain type name: " + ex.getMessage());
+  }
+
+  @Test
+  public void testInvalidDateTimeStringExceptionContainsBadInput() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class, () ->
+        formatter.parse("NOT-A-DATE-------T-", instructions(19, "yyyy-MM-dd'T'HH:mm:ss")));
+    assertTrue(ex.getMessage().contains("NOT-A-DATE-------T-"),
+        "message should contain bad input: " + ex.getMessage());
+  }
+
+  // --- Non-space padding char ---
+
+  @Test
+  public void testStarPaddingChar_leftAlign_roundTrip() {
+    FormatInstructions instr = new FormatInstructions(21, Align.LEFT, '*',
+        new FixedFormatPatternData("yyyy-MM-dd'T'HH:mm:ss"), null, null, null);
+    LocalDateTime original = LocalDateTime.of(2026, 4, 15, 10, 30, 0);
+    String formatted = formatter.format(original, instr);
+    assertEquals("2026-04-15T10:30:00**", formatted);
+    assertEquals(original, formatter.parse(formatted, instr));
+  }
+
+  @Test
+  public void testStarPaddingChar_rightAlign_roundTrip() {
+    FormatInstructions instr = new FormatInstructions(21, Align.RIGHT, '*',
+        new FixedFormatPatternData("yyyy-MM-dd'T'HH:mm:ss"), null, null, null);
+    LocalDateTime original = LocalDateTime.of(2026, 4, 15, 10, 30, 0);
+    String formatted = formatter.format(original, instr);
+    assertEquals("**2026-04-15T10:30:00", formatted);
+    assertEquals(original, formatter.parse(formatted, instr));
+  }
+
   // --- Issue 33: paddingChar appears inside date pattern value ---
 
   @Test

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestRecordInstantiator.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestRecordInstantiator.java
@@ -36,9 +36,46 @@ public class TestRecordInstantiator {
   }
 
   @Test
+  void instantiate_missingDefaultConstructor_exceptionMentionsClassName() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> instantiator.instantiate(NoDefaultConstructorRecord.class));
+    assertTrue(ex.getMessage().contains(NoDefaultConstructorRecord.class.getName()),
+        "message should name the class: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains("default constructor"),
+        "message should mention 'default constructor': " + ex.getMessage());
+  }
+
+  @Test
   void instantiate_declaringClassMissingDefaultConstructor_throwsFixedFormatException() {
     assertThrows(FixedFormatException.class,
         () -> instantiator.instantiate(NoDefaultConstructorHost.InnerRecord.class));
+  }
+
+  @Test
+  void instantiate_declaringClassMissingDefaultConstructor_exceptionMentionsBothClasses() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> instantiator.instantiate(NoDefaultConstructorHost.InnerRecord.class));
+    String msg = ex.getMessage();
+    assertTrue(msg.contains("InnerRecord") || msg.contains("NoDefaultConstructorHost"),
+        "message should mention one of the involved classes: " + msg);
+    assertTrue(msg.contains("default constructor"),
+        "message should mention 'default constructor': " + msg);
+  }
+
+  @Test
+  void instantiate_privateNoArgConstructor_throwsFixedFormatException() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> instantiator.instantiate(PrivateConstructorRecord.class));
+    assertNotNull(ex.getMessage(), "exception message should not be null");
+  }
+
+  @Test
+  void instantiate_declaringClassConstructorThrows_throwsFixedFormatExceptionWithMessage() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> instantiator.instantiate(ThrowingConstructorHost.InnerRecord.class));
+    String msg = ex.getMessage();
+    assertTrue(msg.contains("ThrowingConstructorHost") || msg.contains("unable"),
+        "message should be informative about the failure: " + msg);
   }
 
   // --- Fixture classes ---
@@ -77,6 +114,28 @@ public class TestRecordInstantiator {
 
   public static class NoDefaultConstructorHost {
     public NoDefaultConstructorHost(String required) {}
+
+    @Record
+    public class InnerRecord {
+      @Field(offset = 1, length = 5)
+      public String getValue() { return null; }
+      public void setValue(String v) {}
+    }
+  }
+
+  @Record
+  public static class PrivateConstructorRecord {
+    private PrivateConstructorRecord() {}
+
+    @Field(offset = 1, length = 5)
+    public String getValue() { return null; }
+    public void setValue(String v) {}
+  }
+
+  public static class ThrowingConstructorHost {
+    public ThrowingConstructorHost() {
+      throw new RuntimeException("host constructor always fails");
+    }
 
     @Record
     public class InnerRecord {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/io/TestFixedFormatReaderParseError.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/io/TestFixedFormatReaderParseError.java
@@ -83,4 +83,67 @@ class TestFixedFormatReaderParseError {
     List<Object> results = reader.read(new StringReader("line1     \nline2     ")).getAll();
     assertEquals(1, results.size());
   }
+
+  @Test
+  void throwExceptionStrategy_rethrowsOnBadLine() {
+    FixedFormatReader reader = FixedFormatReader.builder()
+        .addMapping(TenCharRecord.class, LinePattern.matchAll())
+        .parseErrorStrategy(ParseErrorStrategy.throwException())
+        .manager(failOnSecondCall())
+        .build();
+
+    assertThrows(FixedFormatException.class, () ->
+        reader.read(new StringReader("line1     \nline2     ")));
+  }
+
+  @Test
+  void throwExceptionStrategy_doesNotContinuePastBadLine() {
+    AtomicInteger processedCount = new AtomicInteger(0);
+    FixedFormatManager countingManager = new FixedFormatManager() {
+      private final AtomicInteger calls = new AtomicInteger(0);
+      @Override public <T> T load(Class<T> clazz, String data) {
+        int call = calls.incrementAndGet();
+        if (call == 1) throw new FixedFormatException("bad first line");
+        processedCount.incrementAndGet();
+        return null;
+      }
+      @Override public <T> String export(T instance) { return ""; }
+      @Override public <T> String export(String template, T instance) { return ""; }
+    };
+
+    FixedFormatReader reader = FixedFormatReader.builder()
+        .addMapping(TenCharRecord.class, LinePattern.matchAll())
+        .parseErrorStrategy(ParseErrorStrategy.throwException())
+        .manager(countingManager)
+        .build();
+
+    assertThrows(FixedFormatException.class, () ->
+        reader.read(new StringReader("line1     \nline2     \nline3     ")));
+    assertEquals(0, processedCount.get(), "no lines should be processed after throwException fires");
+  }
+
+  @Test
+  void skipAndLogStrategy_readResultContainsOnlySuccessfulRecords() {
+    FixedFormatReader reader = FixedFormatReader.builder()
+        .addMapping(TenCharRecord.class, LinePattern.matchAll())
+        .parseErrorStrategy(ParseErrorStrategy.skipAndLog())
+        .manager(failOnSecondCall())
+        .build();
+
+    List<Object> results = reader.read(new StringReader("line1     \nline2     \nline3     ")).getAll();
+    assertEquals(2, results.size());
+  }
+
+  @Test
+  void throwExceptionStrategy_wrapsExceptionFromManager() {
+    FixedFormatReader reader = FixedFormatReader.builder()
+        .addMapping(TenCharRecord.class, LinePattern.matchAll())
+        .parseErrorStrategy(ParseErrorStrategy.throwException())
+        .manager(failOnSecondCall())
+        .build();
+
+    FixedFormatException ex = assertThrows(FixedFormatException.class, () ->
+        reader.read(new StringReader("line1     \nline2     ")));
+    assertNotNull(ex, "exception should not be null");
+  }
 }


### PR DESCRIPTION
Implements the test additions described in issue #105.

## Changes

**6 new test files:**
- `TestEnumFormatter` — LITERAL/NUMERIC round-trips, null/empty handling, message assertions on all three error paths
- `TestFixedFormatBooleanData`, `TestFixedFormatDecimalData`, `TestFixedFormatEnumData`, `TestFixedFormatNumberData`, `TestFixedFormatPatternData` — getter correctness, DEFAULT instance values, toString field coverage

**5 extended test files:**
- `TestRecordInstantiator` — exception message assertions; private constructor and throwing-declaring-class fixtures
- `TestByTypeFormatter` — format assertions for all types; enum dispatch; unknown-type message assertion
- `TestDateFormatter`, `TestLocalDateFormatter`, `TestLocalDateTimeFormatter` — exception message assertions; non-space paddingChar round-trips
- `TestFixedFormatReaderParseError` — throwException() strategy tests; ReadResult size assertions

No production source files changed.

Closes #105

Generated with [Claude Code](https://claude.ai/code)