### PR TITLE
test: wave 2 mutation coverage for FixedFormatManagerImpl

### DIFF
--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestFixedFormatManagerImpl.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestFixedFormatManagerImpl.java
@@ -16,6 +16,7 @@
 package com.ancientprogramming.fixedformat4j.format.impl;
 
 import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.Fields;
 import com.ancientprogramming.fixedformat4j.annotation.FixedFormatPattern;
 import com.ancientprogramming.fixedformat4j.annotation.Record;
 import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
@@ -440,5 +441,334 @@ public class TestFixedFormatManagerImpl {
     @FixedFormatPattern("yyyyjj")
     public LocalDateTime getEventDateTime() { return eventDateTime; }
     public void setEventDateTime(LocalDateTime eventDateTime) { this.eventDateTime = eventDateTime; }
+  }
+
+  // --- Cluster B: load() edge paths ---
+
+  @Test
+  public void testLoad_fieldsAnnotation_onlyFirstFieldUsed() {
+    // @Fields with two offsets having DISTINCT data — only offset=1 should be loaded
+    TwoFieldsDifferentRecord rec = manager.load(TwoFieldsDifferentRecord.class, "ABCDEF");
+    assertEquals("ABC", rec.getValue(),
+        "Only the first @Field in @Fields should be loaded; got: " + rec.getValue());
+  }
+
+  @Test
+  public void testLoad_nullCharAllMatch_fieldIsNull() {
+    NullCharStringRecord rec = manager.load(NullCharStringRecord.class, "     ");
+    assertNull(rec.getText(), "All nullChars in slice → field should be null");
+  }
+
+  @Test
+  public void testLoad_nullCharPartialMatch_fieldIsParsed() {
+    NullCharStringRecord rec = manager.load(NullCharStringRecord.class, "hel  ");
+    assertNotNull(rec.getText(), "Partial nullChar match → field should not be null");
+    assertEquals("hel", rec.getText());
+  }
+
+  @Test
+  public void testLoad_nullCharInactive_spacesLoadNormally() {
+    NoNullCharStringRecord rec = manager.load(NoNullCharStringRecord.class, "     ");
+    // No nullChar → formatter strips trailing spaces → empty string (not null)
+    assertEquals("", rec.getText());
+  }
+
+  @Test
+  public void testLoad_readOnlyField_doesNotThrow() {
+    ReadOnlyFieldRecord rec = manager.load(ReadOnlyFieldRecord.class, "hello");
+    assertNotNull(rec, "Load of record with read-only field should not throw");
+    assertNull(rec.getText(), "Read-only field has no setter — value stays at default null");
+  }
+
+  @Test
+  public void testLoad_nestedRecord_recursivelyLoadedValue() {
+    // Asserts that the recursively-loaded value is correct, not just that load didn't throw
+    NestedContainerRecord rec = manager.load(NestedContainerRecord.class, "HELLO");
+    assertNotNull(rec.getInner(), "Nested @Record field should be loaded recursively");
+    assertEquals("HELLO", rec.getInner().getText(),
+        "Recursively-loaded value should match the data slice");
+  }
+
+  @Test
+  public void testLoad_nestedRecord_roundTrip() {
+    NestedContainerRecord outer = new NestedContainerRecord();
+    NestedInnerRecord inner = new NestedInnerRecord();
+    inner.setText("WORLD");
+    outer.setInner(inner);
+    String exported = manager.export(outer);
+    NestedContainerRecord loaded = manager.load(NestedContainerRecord.class, exported);
+    assertNotNull(loaded.getInner());
+    assertEquals("WORLD", loaded.getInner().getText());
+  }
+
+  // --- Cluster C: export() edge paths ---
+
+  @Test
+  public void testExport_nestedRecord_nullValue_outputsPadding() {
+    NullableNestedRecord rec = new NullableNestedRecord();
+    // inner == null → isNestedRecord=true, valueObject=null → padding only
+    String exported = manager.export(rec);
+    assertEquals("     ", exported,
+        "Null nested @Record field should export as padding chars");
+  }
+
+  @Test
+  public void testExport_nestedRecord_nonNullValue_recursivelyExported() {
+    NullableNestedRecord rec = new NullableNestedRecord();
+    NestedInnerRecord inner = new NestedInnerRecord();
+    inner.setText("HI");
+    rec.setInner(inner);
+    String exported = manager.export(rec);
+    assertEquals("HI   ", exported,
+        "Non-null nested @Record field should be recursively exported");
+  }
+
+  @Test
+  public void testExport_nullValue_nullCharActive_outputsNullChar() {
+    NullCharExportRecord rec = new NullCharExportRecord();
+    // value == null, nullChar='0' active → "00000"
+    String exported = manager.export(rec);
+    assertEquals("00000", exported,
+        "Null value with active nullChar should export as repeated nullChar");
+  }
+
+  @Test
+  public void testExport_nullValue_nullCharInactive_outputsDefault() {
+    NoNullCharExportRecord rec = new NoNullCharExportRecord();
+    // value == null, no nullChar → formatter handles null → "     " (space-padded)
+    String exported = manager.export(rec);
+    assertEquals("     ", exported,
+        "Null value without nullChar should export as formatter default (space padding)");
+  }
+
+  @Test
+  public void testExport_recordLengthExactBoundary_noPaddingAdded() {
+    // Record length == exported string length: the padding while-loop must NOT execute
+    ExactLengthRecord rec = new ExactLengthRecord();
+    rec.setName("hello");
+    String exported = manager.export(rec);
+    assertEquals("hello", exported);
+    assertEquals(5, exported.length());
+  }
+
+  @Test
+  public void testExport_recordLengthUnbounded_noExtraPadding() {
+    // @Record with default length=-1: no padding loop runs after export
+    UnboundedRecord rec = new UnboundedRecord();
+    rec.setName("hi");
+    String exported = manager.export(rec);
+    // field length=5, "hi" left-padded → "hi   "
+    assertEquals("hi   ", exported);
+  }
+
+  @Test
+  public void testExport_repeatingField_delegatesToRepeatingFieldSupport() {
+    RepeatingFieldRecord rec = new RepeatingFieldRecord();
+    rec.setCodes(new String[]{"AAA", "BBB", "CCC"});
+    rec.setAmounts(new Integer[]{42, 99});
+    String exported = manager.export(rec);
+    assertEquals("AAA  BBB  CCC  0004200099", exported);
+  }
+
+  // --- Cluster D: appendData boundaries ---
+
+  @Test
+  public void testAppendData_fieldAtOffset1_noGapPaddingNeeded() {
+    // zeroBasedOffset=0, result.length()==0 → while-loop does not execute
+    GaplessRecord rec = new GaplessRecord();
+    rec.setData("AB");
+    String exported = manager.export(rec);
+    assertEquals("AB   ", exported);
+  }
+
+  @Test
+  public void testAppendData_fieldAtOffset5_gapIsPadded() {
+    // zeroBasedOffset=4, result starts as "", while-loop pads 4 spaces
+    GapAtOffset5Record rec = new GapAtOffset5Record();
+    rec.setData("XY");
+    String exported = manager.export(rec);
+    // 4 spaces (gap) + "XY " (field, left-padded to 3 chars)
+    assertEquals("    XY ", exported);
+  }
+
+  @Test
+  public void testAppendData_twoNonAdjacentFields_gapFilledWithPadding() {
+    // field A at offset 1 (length 3), field B at offset 8 (length 3)
+    // gap between offset 4 and 7 should be filled with paddingChar
+    TwoGapFieldsRecord rec = new TwoGapFieldsRecord();
+    rec.setA("AA");
+    rec.setB("BB");
+    String exported = manager.export(rec);
+    // "AA " + 4 spaces gap + "BB "
+    assertEquals("AA     BB ", exported);
+  }
+
+  @Test
+  public void testAppendData_exportWithTemplate_fieldsOverwriteTemplate() {
+    // Uses export(template, record) to test that appendData replaces template chars
+    TwoGapFieldsRecord rec = new TwoGapFieldsRecord();
+    rec.setA("AA");
+    rec.setB("BB");
+    String exported = manager.export("xxxxxxxxxx", rec);
+    // template "xxxxxxxxxx", field A at 0-2 → "AA x", field B at 7-9 → "BB "
+    assertEquals("AA xxxx BB ", exported);
+  }
+
+  // --- Cluster B/C: record annotation properties verified via behavior ---
+
+  @Test
+  public void testRecordAnnotation_paddingChar_usedForFieldGaps() {
+    StarPaddedRecord rec = new StarPaddedRecord();
+    rec.setData("AB");
+    String exported = manager.export(rec);
+    // Field at offset 5 (length 3), record paddingChar='*'
+    // gap = "****" (4 stars) + field "AB " (left-padded to 3)
+    // Wait, the field paddingChar default is ' '. But the GAP uses record.paddingChar().
+    // The formatter pads the field value with fieldAnnotation.paddingChar() = ' ' (default).
+    // appendData uses record.paddingChar()='*' for gap padding.
+    // So: "****" (gap from appendData while-loop) + "AB " (formatted field, space-padded)
+    assertEquals("****AB ", exported);
+  }
+
+  // --- Inner record classes for edge case tests ---
+
+  @Record
+  public static class TwoFieldsDifferentRecord {
+    private String value;
+
+    @Fields({@Field(offset = 1, length = 3), @Field(offset = 4, length = 3)})
+    public String getValue() { return value; }
+    public void setValue(String v) { this.value = v; }
+  }
+
+  @Record
+  public static class NullCharStringRecord {
+    private String text;
+
+    @Field(offset = 1, length = 5, nullChar = ' ')
+    public String getText() { return text; }
+    public void setText(String text) { this.text = text; }
+  }
+
+  @Record
+  public static class NoNullCharStringRecord {
+    private String text;
+
+    @Field(offset = 1, length = 5)
+    public String getText() { return text; }
+    public void setText(String text) { this.text = text; }
+  }
+
+  @Record
+  public static class ReadOnlyFieldRecord {
+    private String text;
+
+    @Field(offset = 1, length = 5)
+    public String getText() { return text; }
+    // No setter — setterHandle will be null in FieldDescriptor
+  }
+
+  @Record
+  public static class NestedInnerRecord {
+    private String text;
+
+    @Field(offset = 1, length = 5)
+    public String getText() { return text; }
+    public void setText(String text) { this.text = text; }
+  }
+
+  @Record
+  public static class NestedContainerRecord {
+    private NestedInnerRecord inner;
+
+    @Field(offset = 1, length = 5)
+    public NestedInnerRecord getInner() { return inner; }
+    public void setInner(NestedInnerRecord inner) { this.inner = inner; }
+  }
+
+  @Record
+  public static class NullableNestedRecord {
+    private NestedInnerRecord inner;
+
+    @Field(offset = 1, length = 5)
+    public NestedInnerRecord getInner() { return inner; }
+    public void setInner(NestedInnerRecord inner) { this.inner = inner; }
+  }
+
+  @Record
+  public static class NullCharExportRecord {
+    private Integer value;
+
+    @Field(offset = 1, length = 5, nullChar = '0')
+    public Integer getValue() { return value; }
+    public void setValue(Integer value) { this.value = value; }
+  }
+
+  @Record
+  public static class NoNullCharExportRecord {
+    private String value;
+
+    @Field(offset = 1, length = 5)
+    public String getValue() { return value; }
+    public void setValue(String value) { this.value = value; }
+  }
+
+  @Record(length = 5)
+  public static class ExactLengthRecord {
+    private String name;
+
+    @Field(offset = 1, length = 5)
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+  }
+
+  @Record
+  public static class UnboundedRecord {
+    private String name;
+
+    @Field(offset = 1, length = 5)
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+  }
+
+  @Record
+  public static class GaplessRecord {
+    private String data;
+
+    @Field(offset = 1, length = 5)
+    public String getData() { return data; }
+    public void setData(String data) { this.data = data; }
+  }
+
+  @Record
+  public static class GapAtOffset5Record {
+    private String data;
+
+    @Field(offset = 5, length = 3)
+    public String getData() { return data; }
+    public void setData(String data) { this.data = data; }
+  }
+
+  @Record
+  public static class TwoGapFieldsRecord {
+    private String a;
+    private String b;
+
+    @Field(offset = 1, length = 3)
+    public String getA() { return a; }
+    public void setA(String a) { this.a = a; }
+
+    @Field(offset = 8, length = 3)
+    public String getB() { return b; }
+    public void setB(String b) { this.b = b; }
+  }
+
+  @Record(paddingChar = '*')
+  public static class StarPaddedRecord {
+    private String data;
+
+    @Field(offset = 5, length = 3)
+    public String getData() { return data; }
+    public void setData(String data) { this.data = data; }
   }
 }

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestFixedFormatManagerImplErrors.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestFixedFormatManagerImplErrors.java
@@ -1,7 +1,9 @@
 package com.ancientprogramming.fixedformat4j.format.impl;
 
 import com.ancientprogramming.fixedformat4j.annotation.Align;
+import com.ancientprogramming.fixedformat4j.annotation.EnumFormat;
 import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.FixedFormatEnum;
 import com.ancientprogramming.fixedformat4j.annotation.Record;
 import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
 import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
@@ -31,8 +33,18 @@ public class TestFixedFormatManagerImplErrors {
   }
 
   @Test
+  public void load_classWithoutRecordAnnotation_exceptionMessageContainsClassAndRecordAnnotation() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.load(String.class, "some data"));
+    String msg = ex.getMessage();
+    assertTrue(msg.contains("String") || msg.contains("java.lang.String"),
+        "Message should contain class name: " + msg);
+    assertTrue(msg.contains("record annotation"),
+        "Message should mention 'record annotation': " + msg);
+  }
+
+  @Test
   public void load_classWithNoDefaultConstructor_throwsFixedFormatException() {
-    // NoDefaultConstructorTopLevel has no default constructor and no declaring class
     assertThrows(FixedFormatException.class, () ->
       manager.load(NoDefaultConstructorClass.MyInnerClass.class, "xyz       ")
     );
@@ -40,7 +52,6 @@ public class TestFixedFormatManagerImplErrors {
 
   @Test
   public void load_unparsableData_throwsParseException() {
-    // "foobar" cannot be parsed as an integer for the integer field
     ParseException ex = assertThrows(ParseException.class, () ->
       manager.load(SimpleIntRecord.class, "foobar")
     );
@@ -54,10 +65,17 @@ public class TestFixedFormatManagerImplErrors {
     ParseException ex = assertThrows(ParseException.class, () ->
       manager.load(SimpleIntRecord.class, "foobar")
     );
-    // failedText is the substring at the field offset/length
     assertNotNull(ex.getFailedText());
     assertNotNull(ex.getFormatContext());
     assertNotNull(ex.getFormatInstructions());
+  }
+
+  @Test
+  public void load_unparsableData_parseExceptionHasCause() {
+    ParseException ex = assertThrows(ParseException.class, () ->
+        manager.load(SimpleIntRecord.class, "foobar")
+    );
+    assertNotNull(ex.getCause(), "ParseException should wrap the original cause");
   }
 
   // --- export() error paths ---
@@ -65,6 +83,146 @@ public class TestFixedFormatManagerImplErrors {
   @Test
   public void export_classWithoutRecordAnnotation_throwsFixedFormatException() {
     assertThrows(FixedFormatException.class, () -> manager.export("not annotated"));
+  }
+
+  @Test
+  public void export_classWithoutRecordAnnotation_exceptionMessageContainsClassAndRecordAnnotation() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.export("not annotated"));
+    String msg = ex.getMessage();
+    assertTrue(msg.contains("String") || msg.contains("java.lang.String"),
+        "Message should contain class name: " + msg);
+    assertTrue(msg.contains("record annotation"),
+        "Message should mention 'record annotation': " + msg);
+  }
+
+  // --- Cluster A: doValidateEnumFieldLength ---
+
+  @Test
+  public void enumField_literalTooLong_throwsWithEnumClassAndLengths() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.load(EnumTooShortLiteralRecord.class, "RED"));
+    String msg = ex.getMessage();
+    assertTrue(msg.contains("RgbColor"), "Message should contain enum class name: " + msg);
+    assertTrue(msg.contains("5"), "Message should contain max length 5: " + msg);
+    assertTrue(msg.contains("3"), "Message should contain field length 3: " + msg);
+    assertTrue(msg.contains("getColor"), "Message should contain getter name: " + msg);
+  }
+
+  @Test
+  public void enumField_numericTooLong_throwsWithMaxLengthAndFieldLength() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.load(EnumTooShortNumericRecord.class, "0"));
+    String msg = ex.getMessage();
+    assertTrue(msg.contains("2"), "Message should contain max length 2 (ordinal 10 needs 2 digits): " + msg);
+    assertTrue(msg.contains("1"), "Message should contain field length 1: " + msg);
+    assertTrue(msg.contains("getVal"), "Message should contain getter name: " + msg);
+  }
+
+  @Test
+  public void enumField_literalFitsExactly_doesNotThrow() {
+    assertDoesNotThrow(() -> manager.load(EnumExactFitRecord.class, "RED  "));
+  }
+
+  // --- Cluster A: doValidateRestOfLineField ---
+
+  @Test
+  public void restOfLineField_nonStringType_throwsWithGetterAndTypeName() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.load(RestOfLineIntRecord.class, "42"));
+    String msg = ex.getMessage();
+    assertTrue(msg.contains("getValue"), "Message should contain getter name: " + msg);
+    assertTrue(msg.contains("int"), "Message should contain type 'int': " + msg);
+    assertTrue(msg.contains("String"), "Message should mention String requirement: " + msg);
+  }
+
+  @Test
+  public void restOfLineField_alignNotInherit_throwsWithGetterRef() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.load(RestOfLineAlignRecord.class, "hello"));
+    String msg = ex.getMessage();
+    assertTrue(msg.contains("getValue"), "Message should contain getter name: " + msg);
+    assertTrue(msg.contains("align"), "Message should mention 'align': " + msg);
+  }
+
+  @Test
+  public void restOfLineField_nonDefaultPaddingChar_throwsWithGetterRef() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.load(RestOfLinePaddingRecord.class, "hello"));
+    String msg = ex.getMessage();
+    assertTrue(msg.contains("getValue"), "Message should contain getter name: " + msg);
+    assertTrue(msg.contains("paddingChar"), "Message should mention 'paddingChar': " + msg);
+  }
+
+  @Test
+  public void restOfLineField_nullCharSet_throwsWithGetterRef() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.load(RestOfLineNullCharRecord.class, "hello"));
+    String msg = ex.getMessage();
+    assertTrue(msg.contains("getValue"), "Message should contain getter name: " + msg);
+    assertTrue(msg.contains("nullChar"), "Message should mention 'nullChar': " + msg);
+  }
+
+  // --- Cluster A: doValidateRestOfLineIsLastField ---
+
+  @Test
+  public void twoRestOfLineFields_throwsWithClassName() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.load(TwoRestOfLineRecord.class, "hello"));
+    String msg = ex.getMessage();
+    assertTrue(msg.contains("TwoRestOfLineRecord"),
+        "Message should contain record class name: " + msg);
+    assertTrue(msg.contains("Only one") || msg.contains("multiple"),
+        "Message should mention single-field constraint: " + msg);
+  }
+
+  @Test
+  public void restOfLineFieldNotLast_throwsWithGetterRefAndOffset() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.load(RestOfLineNotLastRecord.class, "hello world"));
+    String msg = ex.getMessage();
+    assertTrue(msg.contains("getNotes"), "Message should contain REST_OF_LINE getter name: " + msg);
+    assertTrue(msg.contains("7"), "Message should contain maxOtherOffset=7: " + msg);
+  }
+
+  @Test
+  public void repeatingFieldAfterRestOfLine_throwsWithRepeatingEndOffset() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.load(RepeatingAfterRestOfLineRecord.class, "hello"));
+    String msg = ex.getMessage();
+    // repeating field: offset=1, count=3, length=3 → effectiveEndOffset = 1 + 3*3 - 1 = 9
+    // REST_OF_LINE at offset=5
+    assertTrue(msg.contains("9"),
+        "Message should contain effectiveEndOffset=9 (tests repeating formula): " + msg);
+    assertTrue(msg.contains("getRest"), "Message should contain REST_OF_LINE getter name: " + msg);
+  }
+
+  // --- Cluster A: doValidateRestOfLineRecordLength ---
+
+  @Test
+  public void restOfLineWithFixedRecordLength_throwsWithRecordLengthInMessage() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.load(FixedLengthRestOfLineRecord.class, "hello"));
+    String msg = ex.getMessage();
+    assertTrue(msg.contains("20"), "Message should contain record length 20: " + msg);
+    assertTrue(msg.contains("FixedLengthRestOfLineRecord"),
+        "Message should contain class name: " + msg);
+  }
+
+  @Test
+  public void restOfLineWithUnboundedRecordLength_doesNotThrow() {
+    assertDoesNotThrow(() -> manager.load(ValidRestOfLineRecord.class, "hello world"));
+  }
+
+  // --- Cluster A: doValidateFieldNullChar (count > 1 path) ---
+
+  @Test
+  public void nullCharOnRepeatingPrimitiveArray_throwsWithPrimitiveTypeName() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.load(NullCharRepeatingIntRecord.class, "          "));
+    String msg = ex.getMessage();
+    assertTrue(msg.contains("int"), "Message should contain primitive type 'int': " + msg);
+    assertTrue(msg.contains("getValues"), "Message should contain getter name: " + msg);
   }
 
   // --- Helper record classes ---
@@ -81,5 +239,154 @@ public class TestFixedFormatManagerImplErrors {
     public void setNumber(int number) {
       this.number = number;
     }
+  }
+
+  // Enum validation fixtures
+
+  enum RgbColor { RED, GREEN, BLUE }
+
+  @Record
+  public static class EnumTooShortLiteralRecord {
+    private RgbColor color;
+
+    @Field(offset = 1, length = 3)
+    public RgbColor getColor() { return color; }
+    public void setColor(RgbColor color) { this.color = color; }
+  }
+
+  enum ElevenValues { V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, VA }
+
+  @Record
+  public static class EnumTooShortNumericRecord {
+    private ElevenValues val;
+
+    @Field(offset = 1, length = 1)
+    @FixedFormatEnum(EnumFormat.NUMERIC)
+    public ElevenValues getVal() { return val; }
+    public void setVal(ElevenValues val) { this.val = val; }
+  }
+
+  enum ThreeColor { RED, GREEN, BLUE }
+
+  @Record
+  public static class EnumExactFitRecord {
+    private ThreeColor color;
+
+    @Field(offset = 1, length = 5)
+    public ThreeColor getColor() { return color; }
+    public void setColor(ThreeColor color) { this.color = color; }
+  }
+
+  // REST_OF_LINE validation fixtures
+
+  @Record
+  public static class RestOfLineIntRecord {
+    private int value;
+
+    @Field(offset = 1, length = Field.REST_OF_LINE)
+    public int getValue() { return value; }
+    public void setValue(int value) { this.value = value; }
+  }
+
+  @Record
+  public static class RestOfLineAlignRecord {
+    private String value;
+
+    @Field(offset = 1, length = Field.REST_OF_LINE, align = Align.LEFT)
+    public String getValue() { return value; }
+    public void setValue(String value) { this.value = value; }
+  }
+
+  @Record
+  public static class RestOfLinePaddingRecord {
+    private String value;
+
+    @Field(offset = 1, length = Field.REST_OF_LINE, paddingChar = 'X')
+    public String getValue() { return value; }
+    public void setValue(String value) { this.value = value; }
+  }
+
+  @Record
+  public static class RestOfLineNullCharRecord {
+    private String value;
+
+    @Field(offset = 1, length = Field.REST_OF_LINE, nullChar = ' ')
+    public String getValue() { return value; }
+    public void setValue(String value) { this.value = value; }
+  }
+
+  // REST_OF_LINE is-last-field fixtures
+
+  @Record
+  public static class TwoRestOfLineRecord {
+    private String first;
+    private String second;
+
+    @Field(offset = 1, length = Field.REST_OF_LINE)
+    public String getFirst() { return first; }
+    public void setFirst(String first) { this.first = first; }
+
+    @Field(offset = 10, length = Field.REST_OF_LINE)
+    public String getSecond() { return second; }
+    public void setSecond(String second) { this.second = second; }
+  }
+
+  @Record
+  public static class RestOfLineNotLastRecord {
+    private String notes;
+    private String suffix;
+
+    @Field(offset = 1, length = Field.REST_OF_LINE)
+    public String getNotes() { return notes; }
+    public void setNotes(String notes) { this.notes = notes; }
+
+    @Field(offset = 5, length = 3)
+    public String getSuffix() { return suffix; }
+    public void setSuffix(String suffix) { this.suffix = suffix; }
+  }
+
+  @Record
+  public static class RepeatingAfterRestOfLineRecord {
+    private String[] codes;
+    private String rest;
+
+    @Field(offset = 1, length = 3, count = 3)
+    public String[] getCodes() { return codes; }
+    public void setCodes(String[] codes) { this.codes = codes; }
+
+    @Field(offset = 5, length = Field.REST_OF_LINE)
+    public String getRest() { return rest; }
+    public void setRest(String rest) { this.rest = rest; }
+  }
+
+  // REST_OF_LINE record length fixtures
+
+  @Record(length = 20)
+  public static class FixedLengthRestOfLineRecord {
+    private String value;
+
+    @Field(offset = 1, length = Field.REST_OF_LINE)
+    public String getValue() { return value; }
+    public void setValue(String value) { this.value = value; }
+  }
+
+  @Record
+  public static class ValidRestOfLineRecord {
+    private String value;
+
+    @Field(offset = 1, length = Field.REST_OF_LINE)
+    public String getValue() { return value; }
+    public void setValue(String value) { this.value = value; }
+  }
+
+  // NullChar on repeating primitive array fixture
+
+  @Record
+  public static class NullCharRepeatingIntRecord {
+    private int[] values;
+
+    @Field(offset = 1, length = 5, count = 2, nullChar = ' ')
+    public int[] getValues() { return values; }
+    public void setValues(int[] values) { this.values = values; }
   }
 }

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestFixedFormatManagerImplLegacyApi.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestFixedFormatManagerImplLegacyApi.java
@@ -1,0 +1,177 @@
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.Record;
+import com.ancientprogramming.fixedformat4j.format.ParseException;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the deprecated {@code readDataAccordingFieldAnnotation} API (Cluster F).
+ *
+ * <p>The method is {@code protected} on {@link FixedFormatManagerImpl}; tests use an
+ * anonymous subclass as the minimal seam to invoke it directly. The main {@code load()} path
+ * uses {@link ClassMetadataCache} and does NOT call this method, so existing tests do not
+ * cover it — surviving mutants accumulate here.
+ *
+ * <p>Note: the {@code count != 1} path that delegates to {@link RepeatingFieldSupport} is
+ * covered by {@link #readData_repeatingField_returnsArray()}.
+ */
+@SuppressWarnings("deprecation")
+public class TestFixedFormatManagerImplLegacyApi {
+
+  // Same package as FixedFormatManagerImpl — protected method accessible without subclassing.
+  private final FixedFormatManagerImpl manager = new FixedFormatManagerImpl();
+
+  // --- F1: Normal single-field parse ---
+
+  @Test
+  public void readData_singleStringField_parsesValue() throws Exception {
+    Method getter = LegacySimpleRecord.class.getMethod("getText");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    Object result = manager.readDataAccordingFieldAnnotation(
+        LegacySimpleRecord.class, "hello     ", getter, getter, fieldAnno);
+    assertEquals("hello", result,
+        "Should parse the string value at the given offset/length");
+  }
+
+  @Test
+  public void readData_singleIntegerField_parsesValue() throws Exception {
+    Method getter = LegacyIntRecord.class.getMethod("getNumber");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    Object result = manager.readDataAccordingFieldAnnotation(
+        LegacyIntRecord.class, "00042", getter, getter, fieldAnno);
+    assertEquals(42, result,
+        "Should parse the integer value (with leading-zero padding stripped)");
+  }
+
+  // --- F2: Repeating field (count > 1) ---
+
+  @Test
+  public void readData_repeatingField_returnsArray() throws Exception {
+    Method getter = LegacyRepeatingRecord.class.getMethod("getCodes");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    Object result = manager.readDataAccordingFieldAnnotation(
+        LegacyRepeatingRecord.class, "AAABBBCCC", getter, getter, fieldAnno);
+    assertNotNull(result, "Repeating field result should not be null");
+    assertInstanceOf(String[].class, result, "Repeating String field should return String[]");
+    String[] codes = (String[]) result;
+    assertEquals(3, codes.length);
+    assertEquals("AAA", codes[0]);
+    assertEquals("BBB", codes[1]);
+    assertEquals("CCC", codes[2]);
+  }
+
+  // --- F3: Nested @Record type — recursive load ---
+
+  @Test
+  public void readData_nestedRecordField_recursivelyLoadsInnerRecord() throws Exception {
+    Method getter = LegacyContainerRecord.class.getMethod("getInner");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    Object result = manager.readDataAccordingFieldAnnotation(
+        LegacyContainerRecord.class, "hello", getter, getter, fieldAnno);
+    assertNotNull(result, "Nested @Record field result should not be null");
+    assertInstanceOf(LegacyInnerRecord.class, result,
+        "Result should be an instance of the nested record type");
+    LegacyInnerRecord inner = (LegacyInnerRecord) result;
+    assertEquals("hello", inner.getText(),
+        "Recursively-loaded inner record should contain the correct value");
+  }
+
+  // --- F4: RuntimeException → ParseException wrap ---
+
+  @Test
+  public void readData_parseFails_throwsParseExceptionWithCause() throws Exception {
+    Method getter = LegacyIntRecord.class.getMethod("getNumber");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    ParseException ex = assertThrows(ParseException.class, () ->
+        manager.readDataAccordingFieldAnnotation(
+            LegacyIntRecord.class, "XXXXX", getter, getter, fieldAnno)
+    );
+    assertNotNull(ex.getCause(),
+        "ParseException should wrap the original RuntimeException as its cause");
+    assertEquals("XXXXX", ex.getCompleteText(),
+        "ParseException.completeText should be the full input data string");
+    assertEquals(LegacyIntRecord.class, ex.getAnnotatedClass(),
+        "ParseException.annotatedClass should be the record class passed to the method");
+    assertEquals("getNumber", ex.getAnnotatedMethod().getName(),
+        "ParseException.annotatedMethod should be the getter passed to the method");
+  }
+
+  @Test
+  public void readData_parseFails_parseExceptionMessageContainsFieldInfo() throws Exception {
+    Method getter = LegacyIntRecord.class.getMethod("getNumber");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    ParseException ex = assertThrows(ParseException.class, () ->
+        manager.readDataAccordingFieldAnnotation(
+            LegacyIntRecord.class, "XXXXX", getter, getter, fieldAnno)
+    );
+    String msg = ex.getMessage();
+    assertNotNull(msg);
+    assertTrue(msg.contains("XXXXX") || msg.contains("getNumber"),
+        "ParseException message should reference the field or data: " + msg);
+  }
+
+  // --- F5: annotationSource differs from getter (field-level annotation) ---
+
+  @Test
+  public void readData_annotationSourceIsGetter_parsesCorrectly() throws Exception {
+    Method getter = LegacySimpleRecord.class.getMethod("getText");
+    Field fieldAnno = getter.getAnnotation(Field.class);
+    // annotationSource same as getter — standard case
+    Object result = manager.readDataAccordingFieldAnnotation(
+        LegacySimpleRecord.class, "world     ", getter, (AnnotatedElement) getter, fieldAnno);
+    assertEquals("world", result);
+  }
+
+  // --- Record fixtures for legacy API tests ---
+
+  @Record
+  public static class LegacySimpleRecord {
+    private String text;
+
+    @Field(offset = 1, length = 10)
+    public String getText() { return text; }
+    public void setText(String t) { this.text = t; }
+  }
+
+  @Record
+  public static class LegacyIntRecord {
+    private Integer number;
+
+    @Field(offset = 1, length = 5, align = com.ancientprogramming.fixedformat4j.annotation.Align.RIGHT, paddingChar = '0')
+    public Integer getNumber() { return number; }
+    public void setNumber(Integer n) { this.number = n; }
+  }
+
+  @Record
+  public static class LegacyRepeatingRecord {
+    private String[] codes;
+
+    @Field(offset = 1, length = 3, count = 3)
+    public String[] getCodes() { return codes; }
+    public void setCodes(String[] c) { this.codes = c; }
+  }
+
+  @Record
+  public static class LegacyInnerRecord {
+    private String text;
+
+    @Field(offset = 1, length = 5)
+    public String getText() { return text; }
+    public void setText(String t) { this.text = t; }
+  }
+
+  @Record
+  public static class LegacyContainerRecord {
+    private LegacyInnerRecord inner;
+
+    @Field(offset = 1, length = 5)
+    public LegacyInnerRecord getInner() { return inner; }
+    public void setInner(LegacyInnerRecord i) { this.inner = i; }
+  }
+}


### PR DESCRIPTION
Closes #107

## Summary

- Adds ~45 new tests targeting the ~115 surviving mutants in `FixedFormatManagerImpl` (clusters A–F from the issue)
- Exception message assertions kill string-substitution mutants in all 6 `doValidate*` methods
- New `TestFixedFormatManagerImplLegacyApi` covers the deprecated `readDataAccordingFieldAnnotation` path that was entirely untested
- Dead code finding: `doValidateRestOfLineField`'s `count≠1` check is unreachable (flagged, not deleted)

## Test plan

- [ ] CI green: `mvn test -pl fixedformat4j`
- [ ] After merge, trigger `pit-report.yml` and verify `FixedFormatManagerImpl` mutation coverage rises from 75% to ≥88%

Generated with [Claude Code](https://claude.ai/code)