### PR TITLE
feat: lazy openStream() API on FixedFormatReader (#115)

### DIFF
--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/io/read/FixedFormatReader.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/io/read/FixedFormatReader.java
@@ -33,6 +33,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static java.lang.String.format;
 
@@ -286,6 +288,155 @@ public final class FixedFormatReader {
   public void process(Path path, Charset charset, HandlerRegistry registry) {
     Objects.requireNonNull(registry, "registry must not be null");
     withReader(path, charset, r -> { process(r, registry); return null; });
+  }
+
+  // --- openStream ---
+
+  /**
+   * Returns a lazy {@link Stream} of parsed records backed by {@code reader}.
+   *
+   * <p>The caller is responsible for closing the stream. The underlying reader is closed
+   * automatically when the stream is closed. Always use {@code try}-with-resources:</p>
+   * <pre>{@code
+   * try (Stream<Object> s = reader.openStream(source)) {
+   *     s.forEach(this::handleRecord);
+   * }
+   * }</pre>
+   *
+   * @param reader the source of lines; closed when the returned stream is closed
+   * @return a lazy, ordered, non-null stream of parsed record objects
+   * @throws NullPointerException if {@code reader} is {@code null}
+   */
+  public Stream<Object> openStream(Reader reader) {
+    Objects.requireNonNull(reader, "reader must not be null");
+    BufferedReader buffered = toBuffered(reader);
+    return StreamSupport.stream(new FixedFormatSpliterator(buffered, processor), false)
+        .onClose(() -> {
+          try {
+            buffered.close();
+          } catch (IOException e) {
+            throw new FixedFormatIOException("IO error closing stream", e);
+          }
+        });
+  }
+
+  /**
+   * Returns a lazy {@link Stream} of parsed records from {@code inputStream} using UTF-8 encoding.
+   *
+   * <p>The caller must close the returned stream (via {@code try}-with-resources).
+   * Closing the stream closes the underlying input stream.</p>
+   *
+   * @param inputStream the source stream; closed when the returned stream is closed
+   * @return a lazy, ordered, non-null stream of parsed record objects
+   * @throws NullPointerException if {@code inputStream} is {@code null}
+   */
+  public Stream<Object> openStream(InputStream inputStream) {
+    return openStream(inputStream, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Returns a lazy {@link Stream} of parsed records from {@code inputStream} using the given charset.
+   *
+   * <p>The caller must close the returned stream (via {@code try}-with-resources).
+   * Closing the stream closes the underlying input stream.</p>
+   *
+   * @param inputStream the source stream; closed when the returned stream is closed
+   * @param charset     the character encoding to apply
+   * @return a lazy, ordered, non-null stream of parsed record objects
+   * @throws NullPointerException if {@code inputStream} or {@code charset} is {@code null}
+   */
+  public Stream<Object> openStream(InputStream inputStream, Charset charset) {
+    Objects.requireNonNull(inputStream, "inputStream must not be null");
+    Objects.requireNonNull(charset, "charset must not be null");
+    return openStream(new InputStreamReader(inputStream, charset));
+  }
+
+  /**
+   * Returns a lazy {@link Stream} of parsed records from {@code path} using UTF-8 encoding.
+   *
+   * <p>The caller must close the returned stream (via {@code try}-with-resources).
+   * Closing the stream closes the underlying file.</p>
+   *
+   * @param path the path to read
+   * @return a lazy, ordered, non-null stream of parsed record objects
+   * @throws NullPointerException   if {@code path} is {@code null}
+   * @throws FixedFormatIOException if the path cannot be opened
+   */
+  public Stream<Object> openStream(Path path) {
+    return openStream(path, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Returns a lazy {@link Stream} of parsed records from {@code path} using the given charset.
+   *
+   * <p>The caller must close the returned stream (via {@code try}-with-resources).
+   * Closing the stream closes the underlying file.</p>
+   *
+   * @param path    the path to read
+   * @param charset the character encoding to apply
+   * @return a lazy, ordered, non-null stream of parsed record objects
+   * @throws NullPointerException   if {@code path} or {@code charset} is {@code null}
+   * @throws FixedFormatIOException if the path cannot be opened
+   */
+  public Stream<Object> openStream(Path path, Charset charset) {
+    Objects.requireNonNull(path, "path must not be null");
+    Objects.requireNonNull(charset, "charset must not be null");
+    try {
+      return openStream(new InputStreamReader(Files.newInputStream(path), charset));
+    } catch (IOException e) {
+      throw new FixedFormatIOException(format("Cannot open path: %s", path), e);
+    }
+  }
+
+  /**
+   * Returns a lazy {@link Stream} of parsed records of type {@code clazz} from {@code reader}.
+   *
+   * <p>Lines that produce a record of a different type are silently filtered out.
+   * The caller must close the returned stream (via {@code try}-with-resources).</p>
+   *
+   * @param <T>    the record type
+   * @param reader the source of lines; closed when the returned stream is closed
+   * @param clazz  the type to retain; records of other types are discarded
+   * @return a lazy, ordered, non-null stream of {@code T} records
+   * @throws NullPointerException if {@code reader} or {@code clazz} is {@code null}
+   */
+  @SuppressWarnings("unchecked")
+  public <T> Stream<T> openStream(Reader reader, Class<T> clazz) {
+    Objects.requireNonNull(clazz, "clazz must not be null");
+    return openStream(reader).filter(clazz::isInstance).map(r -> (T) r);
+  }
+
+  /**
+   * Returns a lazy {@link Stream} of parsed records of type {@code clazz} from {@code inputStream}
+   * using UTF-8 encoding.
+   *
+   * @param <T>         the record type
+   * @param inputStream the source stream; closed when the returned stream is closed
+   * @param clazz       the type to retain; records of other types are discarded
+   * @return a lazy, ordered, non-null stream of {@code T} records
+   * @throws NullPointerException if {@code inputStream} or {@code clazz} is {@code null}
+   */
+  @SuppressWarnings("unchecked")
+  public <T> Stream<T> openStream(InputStream inputStream, Class<T> clazz) {
+    Objects.requireNonNull(clazz, "clazz must not be null");
+    return openStream(inputStream).filter(clazz::isInstance).map(r -> (T) r);
+  }
+
+  /**
+   * Returns a lazy {@link Stream} of parsed records of type {@code clazz} from {@code path}
+   * using UTF-8 encoding.
+   *
+   * @param <T>   the record type
+   * @param path  the path to read
+   * @param clazz the type to retain; records of other types are discarded
+   * @return a lazy, ordered, non-null stream of {@code T} records
+   * @throws NullPointerException   if {@code path} or {@code clazz} is {@code null}
+   * @throws FixedFormatIOException if the path cannot be opened
+   */
+  @SuppressWarnings("unchecked")
+  public <T> Stream<T> openStream(Path path, Class<T> clazz) {
+    Objects.requireNonNull(clazz, "clazz must not be null");
+    return openStream(path).filter(clazz::isInstance).map(r -> (T) r);
   }
 
   // --- factory ---

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/io/read/FixedFormatSpliterator.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/io/read/FixedFormatSpliterator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2004 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ancientprogramming.fixedformat4j.io.read;
+
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatIOException;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+
+import static java.lang.String.format;
+
+class FixedFormatSpliterator extends Spliterators.AbstractSpliterator<Object> {
+
+  private final BufferedReader reader;
+  private final FixedFormatLineProcessor processor;
+  private final ArrayDeque<Object> buffer = new ArrayDeque<>();
+  private long lineNumber = 0L;
+  private boolean exhausted = false;
+
+  FixedFormatSpliterator(BufferedReader reader, FixedFormatLineProcessor processor) {
+    super(Long.MAX_VALUE, ORDERED | NONNULL);
+    this.reader = reader;
+    this.processor = processor;
+  }
+
+  @Override
+  public boolean tryAdvance(Consumer<? super Object> action) {
+    while (buffer.isEmpty()) {
+      if (exhausted) return false;
+      String line;
+      try {
+        line = reader.readLine();
+      } catch (IOException e) {
+        throw new FixedFormatIOException(format("IO error reading line %d", lineNumber + 1), e);
+      }
+      if (line == null) {
+        exhausted = true;
+        return false;
+      }
+      processor.processLine(line, ++lineNumber, (clazz, record) -> buffer.add(record));
+    }
+    action.accept(buffer.poll());
+    return true;
+  }
+}

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/io/TestFixedFormatReaderOpenStream.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/io/TestFixedFormatReaderOpenStream.java
@@ -1,0 +1,334 @@
+package com.ancientprogramming.fixedformat4j.io;
+
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatIOException;
+import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
+import com.ancientprogramming.fixedformat4j.io.read.FixedFormatReader;
+import com.ancientprogramming.fixedformat4j.io.read.LinePattern;
+import com.ancientprogramming.fixedformat4j.io.read.MultiMatchStrategy;
+import com.ancientprogramming.fixedformat4j.io.read.ParseErrorStrategy;
+import com.ancientprogramming.fixedformat4j.io.read.UnmatchStrategy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TestFixedFormatReaderOpenStream {
+
+  @TempDir
+  Path tempDir;
+
+  private FixedFormatReader singleTypeReader() {
+    return FixedFormatReader.builder()
+        .addMapping(TenCharRecord.class, LinePattern.matchAll())
+        .build();
+  }
+
+  private FixedFormatReader multiTypeReader() {
+    return FixedFormatReader.builder()
+        .addMapping(TenCharRecord.class, LinePattern.prefix("A"))
+        .addMapping(FiveCharRecord.class, LinePattern.prefix("B"))
+        .build();
+  }
+
+  private Path writeTemp(String content) throws IOException {
+    Path file = tempDir.resolve("test.txt");
+    Files.writeString(file, content, StandardCharsets.UTF_8);
+    return file;
+  }
+
+  private static class TrackingInputStream extends ByteArrayInputStream {
+    boolean closed = false;
+    TrackingInputStream(byte[] buf) { super(buf); }
+    @Override public void close() throws IOException { closed = true; super.close(); }
+  }
+
+  // -----------------------------------------------------------------------
+  // Group 1 — openStream(Reader)
+  // -----------------------------------------------------------------------
+
+  @Test
+  void openStream_reader_returnsAllRecords() {
+    try (Stream<Object> s = singleTypeReader().openStream(new StringReader("hello     \nworld     \nfoo       "))) {
+      List<Object> records = s.collect(Collectors.toList());
+      assertEquals(3, records.size());
+      assertEquals("hello", ((TenCharRecord) records.get(0)).getValue().trim());
+      assertEquals("world", ((TenCharRecord) records.get(1)).getValue().trim());
+      assertEquals("foo",   ((TenCharRecord) records.get(2)).getValue().trim());
+    }
+  }
+
+  @Test
+  void openStream_reader_emptyInput_returnsEmptyStream() {
+    try (Stream<Object> s = singleTypeReader().openStream(new StringReader(""))) {
+      assertEquals(0, s.count());
+    }
+  }
+
+  @Test
+  void openStream_nullReader_throwsNpe() {
+    NullPointerException ex = assertThrows(NullPointerException.class, () ->
+        singleTypeReader().openStream((Reader) null));
+    assertTrue(ex.getMessage().contains("reader"));
+  }
+
+  // -----------------------------------------------------------------------
+  // Group 2 — input source overloads
+  // -----------------------------------------------------------------------
+
+  @Test
+  void openStream_inputStream_utf8Default() {
+    byte[] bytes = "hello     \nworld     ".getBytes(StandardCharsets.UTF_8);
+    try (Stream<Object> s = singleTypeReader().openStream(new ByteArrayInputStream(bytes))) {
+      assertEquals(2, s.count());
+    }
+  }
+
+  @Test
+  void openStream_inputStream_explicitCharset() {
+    byte[] bytes = "hello     \nworld     ".getBytes(StandardCharsets.ISO_8859_1);
+    try (Stream<Object> s = singleTypeReader().openStream(new ByteArrayInputStream(bytes), StandardCharsets.ISO_8859_1)) {
+      assertEquals(2, s.count());
+    }
+  }
+
+  @Test
+  void openStream_path_utf8Default() throws IOException {
+    Path p = writeTemp("hello     \nworld     ");
+    try (Stream<Object> s = singleTypeReader().openStream(p)) {
+      assertEquals(2, s.count());
+    }
+  }
+
+  @Test
+  void openStream_path_explicitCharset() throws IOException {
+    Path p = tempDir.resolve("latin.txt");
+    Files.write(p, "hello     \nworld     ".getBytes(StandardCharsets.ISO_8859_1));
+    try (Stream<Object> s = singleTypeReader().openStream(p, StandardCharsets.ISO_8859_1)) {
+      assertEquals(2, s.count());
+    }
+  }
+
+  @Test
+  void openStream_nullInputStream_throwsNpe() {
+    NullPointerException ex = assertThrows(NullPointerException.class, () ->
+        singleTypeReader().openStream((InputStream) null));
+    assertTrue(ex.getMessage().contains("inputStream"));
+  }
+
+  @Test
+  void openStream_nullInputStreamCharset_throwsNpe() {
+    NullPointerException ex = assertThrows(NullPointerException.class, () ->
+        singleTypeReader().openStream(new ByteArrayInputStream(new byte[0]), (java.nio.charset.Charset) null));
+    assertTrue(ex.getMessage().contains("charset"));
+  }
+
+  @Test
+  void openStream_nullPath_throwsNpe() {
+    NullPointerException ex = assertThrows(NullPointerException.class, () ->
+        singleTypeReader().openStream((Path) null));
+    assertTrue(ex.getMessage().contains("path"));
+  }
+
+  @Test
+  void openStream_nullPathCharset_throwsNpe() throws IOException {
+    Path p = writeTemp("hello     ");
+    NullPointerException ex = assertThrows(NullPointerException.class, () ->
+        singleTypeReader().openStream(p, (java.nio.charset.Charset) null));
+    assertTrue(ex.getMessage().contains("charset"));
+  }
+
+  @Test
+  void openStream_nonExistentPath_throwsFixedFormatIOException() {
+    Path missing = Path.of("/nonexistent/does-not-exist-fixedformat4j.txt");
+    assertThrows(FixedFormatIOException.class, () ->
+        singleTypeReader().openStream(missing));
+  }
+
+  // -----------------------------------------------------------------------
+  // Group 3 — resource management
+  // -----------------------------------------------------------------------
+
+  @Test
+  void openStream_closingStreamClosesUnderlyingInputStream() {
+    TrackingInputStream is = new TrackingInputStream("hello     ".getBytes(StandardCharsets.UTF_8));
+    try (Stream<Object> s = singleTypeReader().openStream(is)) {
+      s.count();
+    }
+    assertTrue(is.closed, "InputStream must be closed after stream is closed");
+  }
+
+  @Test
+  void openStream_earlyTermination_closesUnderlyingInputStream() {
+    TrackingInputStream is = new TrackingInputStream(
+        "hello     \nworld     \nfoo       ".getBytes(StandardCharsets.UTF_8));
+    try (Stream<Object> s = singleTypeReader().openStream(is)) {
+      s.findFirst();
+    }
+    assertTrue(is.closed, "InputStream must be closed even after early termination");
+  }
+
+  @Test
+  void openStream_ioErrorDuringRead_throwsFixedFormatIOExceptionWithLineNumber() {
+    BufferedReader failingOnLine3 = new BufferedReader(new StringReader("")) {
+      private int callCount = 0;
+      @Override public String readLine() throws IOException {
+        callCount++;
+        if (callCount == 1) return "line1     ";
+        if (callCount == 2) return "line2     ";
+        throw new IOException("simulated error");
+      }
+    };
+    FixedFormatIOException ex = assertThrows(FixedFormatIOException.class, () -> {
+      try (Stream<Object> s = singleTypeReader().openStream(failingOnLine3)) {
+        s.count();
+      }
+    });
+    assertEquals("IO error reading line 3", ex.getMessage());
+  }
+
+  // -----------------------------------------------------------------------
+  // Group 4 — strategy interaction via Spliterator
+  // -----------------------------------------------------------------------
+
+  @Test
+  void openStream_allMatchesStrategy_emitsMultipleRecordsFromOneLine() {
+    FixedFormatReader reader = FixedFormatReader.builder()
+        .addMapping(TenCharRecord.class, LinePattern.prefix("A"))
+        .addMapping(TenCharRecord.class, LinePattern.matchAll())
+        .multiMatchStrategy(MultiMatchStrategy.allMatches())
+        .build();
+    try (Stream<Object> s = reader.openStream(new StringReader("AAAAAAAAAA"))) {
+      assertEquals(2, s.count());
+    }
+  }
+
+  @Test
+  void openStream_parseErrorSkipAndLog_streamContinuesAfterErrorLine() {
+    AtomicInteger callCount = new AtomicInteger(0);
+    FixedFormatManager manager = new FixedFormatManager() {
+      @SuppressWarnings("unchecked")
+      @Override public <T> T load(Class<T> clazz, String data) {
+        if (callCount.incrementAndGet() == 2) throw new FixedFormatException("bad data");
+        TenCharRecord r = new TenCharRecord(); r.setValue("ok"); return (T) r;
+      }
+      @Override public <T> String export(T instance) { return ""; }
+      @Override public <T> String export(String template, T instance) { return ""; }
+    };
+
+    FixedFormatReader reader = FixedFormatReader.builder()
+        .addMapping(TenCharRecord.class, LinePattern.matchAll())
+        .parseErrorStrategy(ParseErrorStrategy.skipAndLog())
+        .manager(manager)
+        .build();
+
+    try (Stream<Object> s = reader.openStream(new StringReader("line1     \nline2     \nline3     "))) {
+      assertEquals(2, s.count());
+    }
+  }
+
+  @Test
+  void openStream_unmatchSkip_streamContinuesAfterUnmatchedLine() {
+    FixedFormatReader reader = FixedFormatReader.builder()
+        .addMapping(TenCharRecord.class, LinePattern.prefix("A"))
+        .unmatchStrategy(UnmatchStrategy.skip())
+        .build();
+    try (Stream<Object> s = reader.openStream(new StringReader("AAAAAAAAAA\nBBBBBBBBBB\nAAAAAAAAAAAA"))) {
+      assertEquals(2, s.count());
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Group 5 — typed openStream(source, Class<T>)
+  // -----------------------------------------------------------------------
+
+  @Test
+  void openStream_typedReader_singleType_returnsTypedStreamWithoutCast() {
+    try (Stream<TenCharRecord> s = singleTypeReader().openStream(new StringReader("hello     \nworld     "), TenCharRecord.class)) {
+      List<TenCharRecord> records = s.collect(Collectors.toList());
+      assertEquals(2, records.size());
+      assertEquals("hello", records.get(0).getValue().trim());
+    }
+  }
+
+  @Test
+  void openStream_typedPath_multiType_filtersToRequestedType() throws IOException {
+    Path p = writeTemp("AAAAAAAAAA\nBBBBB\nAAAAAAAAAAAA");
+    try (Stream<TenCharRecord> s = multiTypeReader().openStream(p, TenCharRecord.class)) {
+      assertEquals(2, s.count());
+    }
+  }
+
+  @Test
+  void openStream_typedInputStream_multiType_filtersToRequestedType() {
+    byte[] bytes = "AAAAAAAAAA\nBBBBB\nAAAAAAAAAAAA".getBytes(StandardCharsets.UTF_8);
+    try (Stream<FiveCharRecord> s = multiTypeReader().openStream(new ByteArrayInputStream(bytes), FiveCharRecord.class)) {
+      assertEquals(1, s.count());
+    }
+  }
+
+  @Test
+  void openStream_typedReader_noRecordsMatchType_returnsEmptyStream() {
+    try (Stream<FiveCharRecord> s = multiTypeReader().openStream(new StringReader("AAAAAAAAAA\nAAAAAAAAAAAA"), FiveCharRecord.class)) {
+      assertEquals(0, s.count());
+    }
+  }
+
+  @Test
+  void openStream_typedReader_nullClass_throwsNpe() {
+    NullPointerException ex = assertThrows(NullPointerException.class, () ->
+        singleTypeReader().openStream(new StringReader(""), (Class<Object>) null));
+    assertTrue(ex.getMessage().contains("clazz"));
+  }
+
+  // -----------------------------------------------------------------------
+  // Group 6 — concurrency
+  // -----------------------------------------------------------------------
+
+  @Test
+  void openStream_concurrentCallsOnSameReader_produceIndependentStreams() throws InterruptedException {
+    int threadCount = 10;
+    CyclicBarrier barrier = new CyclicBarrier(threadCount);
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    List<Throwable> errors = new CopyOnWriteArrayList<>();
+    List<Long> sizes = new CopyOnWriteArrayList<>();
+
+    for (int i = 0; i < threadCount; i++) {
+      final int lineCount = (i % 3) + 1;
+      executor.submit(() -> {
+        try {
+          barrier.await();
+          StringBuilder sb = new StringBuilder();
+          for (int j = 0; j < lineCount; j++) {
+            if (j > 0) sb.append('\n');
+            sb.append("line      ");
+          }
+          try (Stream<Object> s = singleTypeReader().openStream(new StringReader(sb.toString()))) {
+            sizes.add(s.count());
+          }
+        } catch (Exception e) {
+          errors.add(e);
+        }
+      });
+    }
+
+    executor.shutdown();
+    assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+    assertTrue(errors.isEmpty(), "Concurrent streams must not produce errors: " + errors);
+    assertEquals(threadCount, sizes.size());
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `FixedFormatSpliterator` — package-private `AbstractSpliterator<Object>` backed by a `BufferedReader` and `ArrayDeque` buffer (characteristics: `ORDERED | NONNULL`)
- Adds 8 `openStream()` methods to `FixedFormatReader`: 5 untyped (`Reader`, `InputStream`, `InputStream+Charset`, `Path`, `Path+Charset`) + 3 typed `<T>` overloads (`Reader`, `InputStream`, `Path`)
- `Stream.onClose()` closes the underlying reader/file when the returned stream is closed — callers use `try`-with-resources

## Design notes

The `ArrayDeque` buffer in the spliterator's `tryAdvance()` loop handles lines that emit **zero** records (excluded, unmatched+skip, parse error+skipAndLog) and the `MultiMatchStrategy.allMatches()` case where one line produces multiple records. Normal single-record lines go through the buffer at zero extra cost.

The `open` prefix follows JDK convention (`openConnection()`, `openInputStream()`) to signal that the caller owns the stream lifecycle.

Typed overloads use `filter(clazz::isInstance).map(r -> (T) r)` — the unchecked cast is safe by invariant (filter already guarantees the type) and avoids the redundant second `isInstance` check inside `Class.cast()`.

## Test plan

- [ ] `mvn test -pl fixedformat4j -Dtest=TestFixedFormatReaderOpenStream` — 24 tests GREEN (6 groups: core spliterator, source overloads, resource management, strategy interaction, typed overloads, concurrency)
- [ ] `mvn test -pl fixedformat4j` — 840 tests total, zero regressions

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)