### PR TITLE
feat: add @Field.nullValue literal null sentinel (#130)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,24 @@ title: Changelog
 
 ### New features
 
+- **`@Field.nullValue` — literal null sentinel string** ([#130](https://github.com/jeyben/fixedformat4j/issues/130)) —
+  Complement to `nullChar` for feeds where the null marker is a specific **mixed-character**
+  string rather than a uniform pad of one character. A slice equal to `nullValue` loads as
+  `null`; a `null` value exports as `nullValue` verbatim, bypassing the formatter.
+
+  ```java
+  // 4-char implied-decimal column: "0000" → 0, "9998" → null, "0501" → 50.1
+  @Field(offset = 1, length = 4, align = Align.RIGHT, paddingChar = '0', nullValue = "9998")
+  @FixedFormatDecimal(decimals = 1)
+  public BigDecimal getRate() { return rate; }
+  ```
+
+  Strictly opt-in (active only when non-empty; default `""`), so existing records are
+  unaffected. Applies per element on repeating fields (`count > 1`), exactly like `nullChar`.
+  Validation rejects a `nullValue` whose length differs from `length`, use on rest-of-line
+  (`length = -1`) or primitive-typed fields, and combining `nullChar` with `nullValue` on
+  the same field — the two attributes are mutually exclusive.
+
 - **Pluggable type registry on `FixedFormatManagerImpl`** ([#116](https://github.com/jeyben/fixedformat4j/issues/116)) —
   Adds a builder API to `FixedFormatManagerImpl` that lets callers register a custom
   type-to-formatter mapping once at startup instead of repeating `formatter=` on every `@Field`

--- a/docs/usage/annotations.md
+++ b/docs/usage/annotations.md
@@ -31,7 +31,8 @@ When placed on a field, the manager derives the getter and setter by name conven
 | `formatter` | `Class<FixedFormatter>` | no | `ByTypeFormatter.class` | The formatter to use when reading and writing the field. |
 | `count` | `int` | no | `1` | Number of consecutive repetitions of this field. When greater than 1, the getter/setter must use an array or an ordered `Collection` (`List`, `Set`, `SortedSet`, etc.). Each repetition occupies `length` characters, starting at `offset + length * index`. |
 | `strictCount` | `boolean` | no | `true` | Only relevant when `count > 1`. If `true` (default), a size mismatch between the array/collection and `count` during export throws a `FixedFormatException`. If `false`, a warning is logged and export proceeds with `min(count, actualSize)` elements. |
-| `nullChar` | `char` | no | `'\0'` | Sentinel character that represents a null value. Null-aware handling is enabled whenever `nullChar` is explicitly set (i.e. differs from the default `'\0'`). On load: if every character in the field slice equals `nullChar`, the setter is not invoked and the field remains `null`. On export: if the getter returns `null`, the field is emitted as `nullChar` repeated `length` times, bypassing the formatter. Setting `nullChar == paddingChar` (since 1.7.2) enables the "blank-is-null" convention — an all-padding slice loads as `null`. For repeating fields (`count > 1`) the check is applied per element. |
+| `nullChar` | `char` | no | `'\0'` | Sentinel character that represents a null value. Null-aware handling is enabled whenever `nullChar` is explicitly set (i.e. differs from the default `'\0'`). On load: if every character in the field slice equals `nullChar`, the setter is not invoked and the field remains `null`. On export: if the getter returns `null`, the field is emitted as `nullChar` repeated `length` times, bypassing the formatter. Setting `nullChar == paddingChar` (since 1.7.2) enables the "blank-is-null" convention — an all-padding slice loads as `null`. For repeating fields (`count > 1`) the check is applied per element. Mutually exclusive with `nullValue`. |
+| `nullValue` | `String` | no | `""` | Literal sentinel string that represents a null value (since 1.9.0). Complement to `nullChar` for **mixed-character** sentinels — e.g. `"9998"` in a 4-char column. Active whenever non-empty. On load: a slice equal to `nullValue` loads as `null`; on export: a `null` value is emitted as `nullValue` verbatim, bypassing the formatter. Must have exactly `length` characters; rejected on rest-of-line (`length = -1`) and primitive-typed fields. For repeating fields (`count > 1`) the check is applied per element. Mutually exclusive with `nullChar`. |
 
 **Alignment values:**
 
@@ -92,6 +93,27 @@ public Date getInvoiceDate() { return invoiceDate; }
 @Field(offset = 9, length = 5, align = Align.RIGHT, paddingChar = '0', nullChar = '0')
 public Integer getQuantity() { return quantity; }
 ```
+
+**Literal sentinel strings with `nullValue`** (since 1.9.0): `nullChar` can only express
+uniform sentinels (every character identical). When the feed uses a **mixed-character**
+sentinel, declare it literally with `nullValue`:
+
+```java
+// 4-char implied-decimal column: "0000" → 0, "9998" → null, "0501" → 50.1
+@Field(offset = 1, length = 4, align = Align.RIGHT, paddingChar = '0', nullValue = "9998")
+@FixedFormatDecimal(decimals = 1)
+public BigDecimal getRate() { return rate; }
+```
+
+- **Activation rule** — null-aware handling fires whenever `nullValue` is non-empty.
+- **On load** — a slice equal to `nullValue` loads as `null` (the setter is not invoked); any other slice is parsed by the formatter as usual.
+- **On export** — a `null` getter value is emitted as `nullValue` verbatim, bypassing the formatter.
+- For repeating fields (`count > 1`) the check is applied **per element**, exactly like `nullChar`.
+
+Validation rejects (with `FixedFormatException`): a `nullValue` whose length differs from
+`length`, `nullValue` on a rest-of-line (`length = -1`) field, `nullValue` on a
+primitive-typed field, and setting both `nullChar` and `nullValue` on the same field —
+the two attributes are mutually exclusive.
 
 ## @Fields
 

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Field.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Field.java
@@ -120,9 +120,43 @@ public @interface Field {
    * {@code int[]}) cannot represent {@code null} and are unaffected by this attribute.
    *
    * @return the character that denotes a null field; defaults to {@link #UNSET_NULL_CHAR} (inactive)
+   * @see #nullValue() for mixed-character sentinels; the two attributes are mutually exclusive
    * @since 1.7.1
    */
   char nullChar() default UNSET_NULL_CHAR;
+
+  /**
+   * Opt-in literal sentinel that represents a {@code null} value in the fixed-width field.
+   * Complement to {@link #nullChar()} for cases where the null marker is a specific
+   * mixed-character string rather than a uniform pad of one character &mdash; e.g. a
+   * 4-char implied-decimal column where {@code "9998"} means {@code null} while
+   * {@code "0000"} means {@code 0}.
+   * <p>
+   * Activation rule: null-aware handling fires whenever {@code nullValue()} is non-empty.
+   * When active:
+   * <ul>
+   *   <li>On load, a slice equal to {@code nullValue} yields {@code null} (the setter is
+   *       not invoked); any other slice is parsed by the formatter as usual.</li>
+   *   <li>On export, a {@code null} getter value is emitted as {@code nullValue} verbatim,
+   *       bypassing the formatter entirely.</li>
+   * </ul>
+   * For repeating fields ({@code count > 1}), the check is applied <em>per element</em>,
+   * exactly like {@link #nullChar()}.
+   * <p>
+   * Constraints enforced at validation time (each violation throws
+   * {@link com.ancientprogramming.fixedformat4j.exception.FixedFormatException}):
+   * <ul>
+   *   <li>{@code nullValue().length()} must equal {@link #length()} when {@code length() >= 0}.</li>
+   *   <li>{@code nullValue()} is rejected on {@code length() == }{@link #REST_OF_LINE} fields.</li>
+   *   <li>{@code nullValue()} is rejected on primitive-typed fields (parity with {@code nullChar}).</li>
+   *   <li>Setting both {@code nullChar() != UNSET_NULL_CHAR} and a non-empty {@code nullValue()}
+   *       on the same field is rejected. They are mutually exclusive.</li>
+   * </ul>
+   *
+   * @return the literal string that denotes a null field; defaults to {@code ""} (inactive)
+   * @since 1.9.0
+   */
+  String nullValue() default "";
 
   /**
    * The formatter class to use for this field.

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FormatInstructions.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FormatInstructions.java
@@ -34,6 +34,7 @@ public class FormatInstructions {
   private final Align alignment;
   private final char paddingChar;
   private final char nullChar;
+  private final String nullValue;
   private final FixedFormatPatternData fixedFormatPatternData;
   private final FixedFormatBooleanData fixedFormatBooleanData;
   private final FixedFormatNumberData fixedFormatNumberData;
@@ -90,10 +91,33 @@ public class FormatInstructions {
    * @since 1.7.1
    */
   public FormatInstructions(int length, Align alignment, char paddingChar, char nullChar, FixedFormatPatternData fixedFormatPatternData, FixedFormatBooleanData fixedFormatBooleanData, FixedFormatNumberData fixedFormatNumberData, FixedFormatDecimalData fixedFormatDecimalData, FixedFormatEnumData fixedFormatEnumData) {
+    this(length, alignment, paddingChar, nullChar, "", fixedFormatPatternData, fixedFormatBooleanData, fixedFormatNumberData, fixedFormatDecimalData, fixedFormatEnumData);
+  }
+
+  /**
+   * Creates a fully-populated set of format instructions including both null sentinels:
+   * the single-character {@code nullChar} and the literal string {@code nullValue}. The
+   * string sentinel is active when non-empty; an empty string disables it and preserves
+   * existing behavior.
+   *
+   * @param length                  the fixed width of the field in characters
+   * @param alignment               the alignment strategy used to pad and strip the field
+   * @param paddingChar             the character used for padding
+   * @param nullChar                the sentinel character signalling a {@code null} field
+   * @param nullValue               the literal sentinel string signalling a {@code null} field; {@code ""} disables it
+   * @param fixedFormatPatternData  date/time pattern configuration, or {@code null} if unused
+   * @param fixedFormatBooleanData  boolean value configuration, or {@code null} if unused
+   * @param fixedFormatNumberData   number sign configuration, or {@code null} if unused
+   * @param fixedFormatDecimalData  decimal precision configuration, or {@code null} if unused
+   * @param fixedFormatEnumData     enum serialization configuration, or {@code null} if unused
+   * @since 1.9.0
+   */
+  public FormatInstructions(int length, Align alignment, char paddingChar, char nullChar, String nullValue, FixedFormatPatternData fixedFormatPatternData, FixedFormatBooleanData fixedFormatBooleanData, FixedFormatNumberData fixedFormatNumberData, FixedFormatDecimalData fixedFormatDecimalData, FixedFormatEnumData fixedFormatEnumData) {
     this.length = length;
     this.alignment = alignment;
     this.paddingChar = paddingChar;
     this.nullChar = nullChar;
+    this.nullValue = nullValue;
     this.fixedFormatPatternData = fixedFormatPatternData;
     this.fixedFormatBooleanData = fixedFormatBooleanData;
     this.fixedFormatNumberData = fixedFormatNumberData;
@@ -138,6 +162,17 @@ public class FormatInstructions {
    */
   public char getNullChar() {
     return nullChar;
+  }
+
+  /**
+   * Returns the literal sentinel string that signals a {@code null} field value. When empty
+   * the null-value detection is disabled and existing behavior is preserved.
+   *
+   * @return the null sentinel string; never {@code null}, {@code ""} when not configured
+   * @since 1.9.0
+   */
+  public String getNullValue() {
+    return nullValue;
   }
 
   /**
@@ -186,7 +221,7 @@ public class FormatInstructions {
   }
 
   public String toString() {
-    return String.format("FormatInstructions{length=%d, alignment=%s, paddingChar='%c', nullChar='%c', fixedFormatPatternData=%s, fixedFormatBooleanData=%s, fixedFormatNumberData=%s, fixedFormatDecimalData=%s, fixedFormatEnumData=%s}",
-        length, alignment, paddingChar, nullChar, fixedFormatPatternData, fixedFormatBooleanData, fixedFormatNumberData, fixedFormatDecimalData, fixedFormatEnumData);
+    return String.format("FormatInstructions{length=%d, alignment=%s, paddingChar='%c', nullChar='%c', nullValue='%s', fixedFormatPatternData=%s, fixedFormatBooleanData=%s, fixedFormatNumberData=%s, fixedFormatDecimalData=%s, fixedFormatEnumData=%s}",
+        length, alignment, paddingChar, nullChar, nullValue, fixedFormatPatternData, fixedFormatBooleanData, fixedFormatNumberData, fixedFormatDecimalData, fixedFormatEnumData);
   }
 }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FieldValidator.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FieldValidator.java
@@ -92,6 +92,10 @@ class FieldValidator {
       throw new FixedFormatException(format(
           "@Field(length = -1): 'nullChar' is not applicable when length = -1 on %s", getterRef));
     }
+    if (!fieldAnnotation.nullValue().isEmpty()) {
+      throw new FixedFormatException(format(
+          "@Field(length = -1): 'nullValue' is not applicable when length = -1 on %s", getterRef));
+    }
   }
 
   static void doValidateRestOfLineIsLastField(Class<?> clazz, List<FieldDescriptor> descriptors) {
@@ -157,6 +161,39 @@ class FieldValidator {
           typeToCheck.getName(),
           target.getter.getDeclaringClass().getName(),
           target.getter.getName()));
+    }
+  }
+
+  static void doValidateNullValue(AnnotationTarget target, Field fieldAnnotation) {
+    if (fieldAnnotation.nullValue().isEmpty()) return;
+    if (fieldAnnotation.length() == Field.REST_OF_LINE) return;
+
+    String getterRef = target.getter.getDeclaringClass().getName() + "." + target.getter.getName() + "()";
+
+    if (fieldAnnotation.nullChar() != Field.UNSET_NULL_CHAR) {
+      throw new FixedFormatException(format(
+          "@Field nullValue \"%s\" and nullChar '%c' are mutually exclusive on %s",
+          fieldAnnotation.nullValue(), fieldAnnotation.nullChar(), getterRef));
+    }
+
+    if (fieldAnnotation.nullValue().length() != fieldAnnotation.length()) {
+      throw new FixedFormatException(format(
+          "@Field nullValue \"%s\" has length %d but the field length is %d on %s",
+          fieldAnnotation.nullValue(), fieldAnnotation.nullValue().length(), fieldAnnotation.length(), getterRef));
+    }
+
+    Class<?> typeToCheck;
+    if (fieldAnnotation.count() > 1) {
+      typeToCheck = new RepeatingFieldSupport().resolveElementType(target.getter);
+    } else {
+      FormatInstructionsBuilder instructionsBuilder = new FormatInstructionsBuilder();
+      typeToCheck = instructionsBuilder.datatype(target.getter, fieldAnnotation);
+    }
+
+    if (typeToCheck.isPrimitive()) {
+      throw new FixedFormatException(format(
+          "@Field nullValue is not supported on primitive type %s on %s",
+          typeToCheck.getName(), getterRef));
     }
   }
 

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
@@ -118,6 +118,7 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
         FieldValidator.doValidateFieldPattern(desc.target, desc.fieldAnnotation);
         FieldValidator.doValidateEnumFieldLength(desc.target, desc.fieldAnnotation);
         FieldValidator.doValidateFieldNullChar(desc.target, desc.fieldAnnotation);
+        FieldValidator.doValidateNullValue(desc.target, desc.fieldAnnotation);
         FieldValidator.doValidateRestOfLineField(desc.target, desc.fieldAnnotation);
       }
       FieldValidator.doValidateRestOfLineIsLastField(clazz, descriptors);
@@ -149,7 +150,7 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
         String dataToParse = fetchData(data, desc.formatInstructions, desc.context);
         if (desc.isNestedRecord) {
           value = load(desc.datatype, dataToParse);
-        } else if (NullCharSupport.isNullSlice(dataToParse, desc.formatInstructions)) {
+        } else if (NullSupport.isNullSliceOrValue(dataToParse, desc.formatInstructions)) {
           value = null;
         } else {
           try {
@@ -207,8 +208,10 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
         formatted = export(valueObject);
       } else if (desc.isNestedRecord) {
         formatted = String.valueOf(desc.fieldAnnotation.paddingChar()).repeat(desc.fieldAnnotation.length());
-      } else if (valueObject == null && NullCharSupport.isNullCharActive(desc.formatInstructions)) {
+      } else if (valueObject == null && NullSupport.isNullCharActive(desc.formatInstructions)) {
         formatted = String.valueOf(desc.formatInstructions.getNullChar()).repeat(desc.formatInstructions.getLength());
+      } else if (valueObject == null && NullSupport.isNullValueActive(desc.formatInstructions)) {
+        formatted = desc.formatInstructions.getNullValue();
       } else {
         formatted = ((FixedFormatter<Object>) desc.formatter).format(valueObject, desc.formatInstructions);
       }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FormatInstructionsBuilder.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FormatInstructionsBuilder.java
@@ -41,7 +41,7 @@ class FormatInstructionsBuilder {
     FixedFormatDecimalData decimalData = decimalData(annotationSource.getAnnotation(FixedFormatDecimal.class));
     FixedFormatEnumData enumData = enumData(annotationSource.getAnnotation(FixedFormatEnum.class));
     Align resolvedAlign = resolveAlign(fieldAnno.align(), declaringClass);
-    return new FormatInstructions(fieldAnno.length(), resolvedAlign, fieldAnno.paddingChar(), fieldAnno.nullChar(), patternData, booleanData, numberData, decimalData, enumData);
+    return new FormatInstructions(fieldAnno.length(), resolvedAlign, fieldAnno.paddingChar(), fieldAnno.nullChar(), fieldAnno.nullValue(), patternData, booleanData, numberData, decimalData, enumData);
   }
 
   private Align resolveAlign(Align fieldAlign, Class<?> declaringClass) {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/NullSupport.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/NullSupport.java
@@ -5,15 +5,17 @@ import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
 import static com.ancientprogramming.fixedformat4j.annotation.Field.UNSET_NULL_CHAR;
 
 /**
- * Shared null-char helpers used by both {@link FixedFormatManagerImpl} and
- * {@link RepeatingFieldSupport}.
+ * Shared null-sentinel helpers used by both {@link FixedFormatManagerImpl} and
+ * {@link RepeatingFieldSupport}. Covers the single-character {@code nullChar}
+ * convention (since 1.7.1) and the literal-string {@code nullValue} convention
+ * (since 1.9.0).
  *
  * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.7.1
  */
-final class NullCharSupport {
+final class NullSupport {
 
-  private NullCharSupport() {}
+  private NullSupport() {}
 
   /**
    * Returns {@code true} when {@code @Field.nullChar()} is explicitly configured (non-sentinel).
@@ -41,5 +43,35 @@ final class NullCharSupport {
       }
     }
     return true;
+  }
+
+  /**
+   * Returns {@code true} when {@code @Field.nullValue()} is explicitly configured.
+   * The default empty string marks "not configured" (Issue 130).
+   *
+   * @since 1.9.0
+   */
+  static boolean isNullValueActive(FormatInstructions instructions) {
+    return !instructions.getNullValue().isEmpty();
+  }
+
+  /**
+   * Returns {@code true} when the raw slice equals the configured {@code nullValue} literal.
+   *
+   * @since 1.9.0
+   */
+  static boolean isNullValueSlice(String slice, FormatInstructions instructions) {
+    return isNullValueActive(instructions) && instructions.getNullValue().equals(slice);
+  }
+
+  /**
+   * Unified load-side check: {@code true} when the slice matches either the
+   * {@code nullChar} or the {@code nullValue} convention. The two are mutually
+   * exclusive per field, enforced by {@link FieldValidator}.
+   *
+   * @since 1.9.0
+   */
+  static boolean isNullSliceOrValue(String slice, FormatInstructions instructions) {
+    return isNullSlice(slice, instructions) || isNullValueSlice(slice, instructions);
   }
 }

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/RepeatingFieldSupport.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/RepeatingFieldSupport.java
@@ -48,7 +48,7 @@ class RepeatingFieldSupport {
     List<Object> elements = new ArrayList<>(desc.elementContexts.length);
     for (FormatContext<?> elementContext : desc.elementContexts) {
       String dataToParse = fetchData(data, formatdata, elementContext);
-      if (!desc.elementType.isPrimitive() && NullCharSupport.isNullSlice(dataToParse, formatdata)) {
+      if (!desc.elementType.isPrimitive() && NullSupport.isNullSliceOrValue(dataToParse, formatdata)) {
         elements.add(null);
         continue;
       }
@@ -105,8 +105,10 @@ class RepeatingFieldSupport {
     for (Object element : iterable) {
       if (i >= exportCount) break;
       int elementOffset = desc.elementContexts[i].getOffset();
-      if (element == null && NullCharSupport.isNullCharActive(formatdata)) {
+      if (element == null && NullSupport.isNullCharActive(formatdata)) {
         foundData.put(elementOffset, String.valueOf(formatdata.getNullChar()).repeat(fieldAnno.length()));
+      } else if (element == null && NullSupport.isNullValueActive(formatdata)) {
+        foundData.put(elementOffset, formatdata.getNullValue());
       } else {
         foundData.put(elementOffset, formatter.format(element, formatdata));
       }

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/issues/TestIssue130NullValue.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/issues/TestIssue130NullValue.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2004 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ancientprogramming.fixedformat4j.issues;
+
+import com.ancientprogramming.fixedformat4j.annotation.Align;
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.FixedFormatDecimal;
+import com.ancientprogramming.fixedformat4j.annotation.Record;
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
+import com.ancientprogramming.fixedformat4j.format.impl.FixedFormatManagerImpl;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies Issue 130 &mdash; {@code @Field.nullValue} declares a literal
+ * mixed-character sentinel string that represents {@code null}, complementing
+ * the uniform single-character {@code nullChar} convention.
+ *
+ * <p>The motivating data shape is a 4-char implied-decimal column where
+ * {@code "0000"} means {@code 0}, {@code "9998"} means {@code null} and
+ * {@code "0501"} means {@code 50.1}.
+ *
+ * @since 1.9.0
+ */
+public class TestIssue130NullValue {
+
+  private final FixedFormatManager manager = FixedFormatManagerImpl.create();
+
+  // ---------------------------------------------------------------------------
+  // Load - literal sentinel slice yields null
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void loadSentinelSliceOnDecimalField_returnsNull() {
+    ImpliedDecimalRecord loaded = manager.load(ImpliedDecimalRecord.class, "9998");
+    assertNull(loaded.getRate());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Load - non-sentinel slices are parsed by the formatter as usual
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void loadAllZerosSlice_parsesAsZero() {
+    ImpliedDecimalRecord loaded = manager.load(ImpliedDecimalRecord.class, "0000");
+    assertEquals(0, BigDecimal.ZERO.compareTo(loaded.getRate()));
+  }
+
+  @Test
+  public void loadRegularSlice_parsesWithImpliedDecimal() {
+    ImpliedDecimalRecord loaded = manager.load(ImpliedDecimalRecord.class, "0501");
+    assertEquals(new BigDecimal("50.1"), loaded.getRate());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Export - null emits the sentinel verbatim, non-null uses the formatter
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void exportNullValue_emitsSentinelVerbatim() {
+    ImpliedDecimalRecord record = new ImpliedDecimalRecord();
+    record.setRate(null);
+    assertEquals("9998", manager.export(record));
+  }
+
+  @Test
+  public void exportRegularValue_usesFormatter() {
+    ImpliedDecimalRecord record = new ImpliedDecimalRecord();
+    record.setRate(new BigDecimal("50.1"));
+    assertEquals("0501", manager.export(record));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Round-trip fidelity
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void roundTripNullValue_isPreserved() {
+    ImpliedDecimalRecord record = new ImpliedDecimalRecord();
+    record.setRate(null);
+    ImpliedDecimalRecord reloaded = manager.load(ImpliedDecimalRecord.class, manager.export(record));
+    assertNull(reloaded.getRate());
+  }
+
+  @Test
+  public void roundTripRegularValue_isPreserved() {
+    ImpliedDecimalRecord record = new ImpliedDecimalRecord();
+    record.setRate(new BigDecimal("50.1"));
+    ImpliedDecimalRecord reloaded = manager.load(ImpliedDecimalRecord.class, manager.export(record));
+    assertEquals(new BigDecimal("50.1"), reloaded.getRate());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Repeating fields - the sentinel is applied per element, like nullChar
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void loadRepeatingField_sentinelElementLoadsAsNull() {
+    RepeatingRecord loaded = manager.load(RepeatingRecord.class, "000199980003");
+    assertEquals(Arrays.asList(1, null, 3), loaded.getAmounts());
+  }
+
+  @Test
+  public void exportRepeatingField_nullElementEmitsSentinel() {
+    RepeatingRecord record = new RepeatingRecord();
+    record.setAmounts(Arrays.asList(1, null, 3));
+    assertEquals("000199980003", manager.export(record));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Validation - misconfigured nullValue is rejected with a clear exception
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void nullValueLengthMismatch_isRejected() {
+    FixedFormatException thrown = assertThrows(FixedFormatException.class,
+        () -> manager.load(LengthMismatchRecord.class, "9998"));
+    assertTrue(thrown.getMessage().contains("getValue"), thrown.getMessage());
+  }
+
+  @Test
+  public void nullValueOnRestOfLineField_isRejected() {
+    FixedFormatException thrown = assertThrows(FixedFormatException.class,
+        () -> manager.load(RestOfLineRecord.class, "data"));
+    assertTrue(thrown.getMessage().contains("getRemainder"), thrown.getMessage());
+  }
+
+  @Test
+  public void nullValueOnPrimitiveField_isRejected() {
+    FixedFormatException thrown = assertThrows(FixedFormatException.class,
+        () -> manager.load(PrimitiveRecord.class, "9998"));
+    assertTrue(thrown.getMessage().contains("getAmount"), thrown.getMessage());
+  }
+
+  @Test
+  public void nullValueCombinedWithNullChar_isRejected() {
+    FixedFormatException thrown = assertThrows(FixedFormatException.class,
+        () -> manager.load(BothSentinelsRecord.class, "9998"));
+    assertTrue(thrown.getMessage().contains("getValue"), thrown.getMessage());
+  }
+
+  @Record(length = 4, paddingChar = '0')
+  public static class ImpliedDecimalRecord {
+    private BigDecimal rate;
+
+    @Field(offset = 1, length = 4, align = Align.RIGHT, paddingChar = '0', nullValue = "9998")
+    @FixedFormatDecimal(decimals = 1)
+    public BigDecimal getRate() {
+      return rate;
+    }
+
+    public void setRate(BigDecimal rate) {
+      this.rate = rate;
+    }
+  }
+
+  @Record(length = 12, paddingChar = '0')
+  public static class RepeatingRecord {
+    private List<Integer> amounts;
+
+    @Field(offset = 1, length = 4, count = 3, align = Align.RIGHT, paddingChar = '0', nullValue = "9998")
+    public List<Integer> getAmounts() {
+      return amounts;
+    }
+
+    public void setAmounts(List<Integer> amounts) {
+      this.amounts = amounts;
+    }
+  }
+
+  @Record(length = 4)
+  public static class LengthMismatchRecord {
+    private String value;
+
+    @Field(offset = 1, length = 4, nullValue = "99")
+    public String getValue() {
+      return value;
+    }
+
+    public void setValue(String value) {
+      this.value = value;
+    }
+  }
+
+  @Record
+  public static class RestOfLineRecord {
+    private String remainder;
+
+    @Field(offset = 1, length = Field.REST_OF_LINE, nullValue = "9998")
+    public String getRemainder() {
+      return remainder;
+    }
+
+    public void setRemainder(String remainder) {
+      this.remainder = remainder;
+    }
+  }
+
+  @Record(length = 4)
+  public static class PrimitiveRecord {
+    private int amount;
+
+    @Field(offset = 1, length = 4, nullValue = "9998")
+    public int getAmount() {
+      return amount;
+    }
+
+    public void setAmount(int amount) {
+      this.amount = amount;
+    }
+  }
+
+  @Record(length = 4)
+  public static class BothSentinelsRecord {
+    private String value;
+
+    @Field(offset = 1, length = 4, nullChar = ' ', nullValue = "9998")
+    public String getValue() {
+      return value;
+    }
+
+    public void setValue(String value) {
+      this.value = value;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `@Field.nullValue` — an opt-in literal sentinel string that represents a `null` field value, complementing `nullChar` for **mixed-character** sentinels that a single uniform character cannot express. Closes #130.

The motivating data shape is a 4-char implied-decimal column:

| Slice | Loads as |
|---|---|
| `"0000"` | `0` |
| `"9998"` | `null` |
| `"0501"` | `50.1` (via `@FixedFormatDecimal(decimals = 1)`) |

```java
@Field(offset = 1, length = 4, align = Align.RIGHT, paddingChar = '0', nullValue = "9998")
@FixedFormatDecimal(decimals = 1)
public BigDecimal getRate() { return rate; }
```

## Changes

- **`@Field.nullValue`** (`String`, default `""` = inactive, `@since 1.9.0`) with full constraint javadoc; cross-referenced from `nullChar`.
- **Load** — a slice equal to `nullValue` loads as `null`, above the formatter layer (`FixedFormatManagerImpl.load()` now uses the unified `NullSupport.isNullSliceOrValue`).
- **Export** — a `null` value emits `nullValue` verbatim, bypassing the formatter (branch alongside the existing `nullChar` one).
- **Repeating fields (`count > 1`)** — applied **per element**, exactly like `nullChar` (`RepeatingFieldSupport` read + export).
- **Validation** (`FieldValidator.doValidateNullValue`, wired into the per-class validation hook) rejects, naming the offending getter:
  - `nullValue.length() != length()`
  - `nullValue` on a rest-of-line (`length = -1`) field
  - `nullValue` on a primitive-typed field
  - `nullChar` and `nullValue` both set (mutually exclusive)
- **`NullCharSupport` → `NullSupport`** rename (package-private; no public-surface impact) with new `isNullValueActive` / `isNullValueSlice` / `isNullSliceOrValue` helpers.
- **`FormatInstructions`** — new constructor overload carrying `nullValue` + `getNullValue()`; existing public constructors delegate unchanged.
- **Docs** — changelog `[Unreleased] 1.9.0` entry and `docs/usage/annotations.md` attribute row + "literal sentinel strings" subsection.

## Framework-breaking checklist

- **Annotation surface** — adds one optional attribute on `@Field`, default `""`. Existing annotations unaffected.
- **Public interfaces** (`FixedFormatManager`, `FixedFormatter<T>`) — unchanged.
- **Extension points** (`AbstractFixedFormatter`, `AbstractNumberFormatter`, `AbstractDecimalFormatter`, `AbstractPatternFormatter`) — unchanged.
- **Activation gates** — one new gate (`!nullValue().isEmpty()`), strictly opt-in; the existing `NullCharSupport.isNullCharActive` gate is untouched.
- **Parse / export semantics** — no change for fields that do not set `nullValue`. Round-trip fidelity (`load(export(x)) == x`) preserved for all existing records.
- **Exception types / messages** — new validation messages only fire on the new attribute; existing messages unchanged.
- **Migration / deprecation** — none required. Source- and binary-compatible additive change (`FormatInstructions` gains an overload; existing constructors delegate).

**Verdict: not framework-breaking — opt-in additive feature.**

## Testing

- New regression suite `TestIssue130NullValue` (13 tests): the five load/export acceptance pairs, round-trip fidelity for null and non-null, per-element repeating-field round-trip, and all four validation rejections.
- Developed RED→GREEN: every test was run and observed failing before its implementation landed.
- Full `mvn install` from the repo root passes on Java 11.
- One deviation from the issue's acceptance text: `"0000"` loads as BigDecimal value `0` (scale 0), not `BigDecimal("0.0")` — that is pre-existing `BigDecimalFormatter` behavior, and changing it would itself be framework-breaking. The test pins value equality instead.

Mutation testing runs in the GitHub Actions pipeline on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)