### PR TITLE
feat: Java record support via canonical-constructor field binding (#119)

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -29,3 +29,22 @@ jobs:
       - name: Build and test with Maven
         run: mvn -B verify
 
+  # Compiles and runs the JDK-17-only test sources (src/test/java17) via the
+  # auto-activated jdk17-tests profile — covers Java record support.
+  build-jdk17:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build and test with Maven
+        run: mvn -B verify
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ The library maps Java POJOs annotated with `@Record` and `@Field` to/from fixed-
 
 **Annotation layer** (`annotation/` package):
 - `@Record` — marks a class as a fixed-format record; declares total length and padding char
-- `@Field` — placed on getter methods; declares `offset` (1-based), `length`, `align`, `paddingChar`, and optional `formatter`
+- `@Field` — placed on getter methods (or record components, since 1.9.0); declares `offset` (1-based), `length`, `align`, `paddingChar`, and optional `formatter`
 - `@Fields` — groups multiple `@Field` annotations on one getter (for multi-format fields)
 - `@FixedFormatNumber`, `@FixedFormatDecimal`, `@FixedFormatBoolean`, `@FixedFormatPattern` — supplementary annotations on getters to control number signs, decimal handling, boolean values, and date/time patterns
 
@@ -75,6 +75,8 @@ The library maps Java POJOs annotated with `@Record` and `@Field` to/from fixed-
 
 **Recursive record support:** If a field's type is itself annotated with `@Record`, `FixedFormatManagerImpl` recursively loads/exports that nested type.
 
+**Java record support (since 1.9.0):** `@Record` classes may be Java `record` types (JDK 16+). Annotations on record components propagate to the accessors; `load()` binds all parsed values through the canonical constructor in one call (`JavaRecordSupport` + `ConstructorBinding`, cached in `ClassMetadataCache`). The artifact stays compiled at release 11 — record APIs are accessed reflectively, once per class.
+
 ## GitHub Actions
 
 All workflows must use Node.js 24 compatible actions (Node.js 20 is removed from runners September 16, 2026):
@@ -84,9 +86,9 @@ All workflows must use Node.js 24 compatible actions (Node.js 20 is removed from
 ## Key Conventions
 
 - Field offsets are **1-based**.
-- `@Field` annotations go on **getter** methods (`get*` or `is*`); the manager derives the setter name by reflection.
+- `@Field` annotations go on **getter** methods (`get*` or `is*`) for conventional POJOs, or on **record components** for Java `record` types (since 1.9.0); the manager derives the setter name by reflection for POJOs, and uses the canonical constructor for records.
 - The default formatter (`ByTypeFormatter`) is chosen automatically from the getter's return type; specify `formatter=` on `@Field` only when overriding.
-- Tests live in `fixedformat4j/src/test/java/` and use JUnit 5 (Jupiter). Issue-specific regression tests are under `issues/` sub-package.
+- Tests live in `fixedformat4j/src/test/java/` and use JUnit 5 (Jupiter). Issue-specific regression tests are under `issues/` sub-package. Tests that need JDK 16+ syntax (e.g. Java records) live in `fixedformat4j/src/test/java17/`, compiled only on JDK 17+ via the auto-activated `jdk17-tests` profile.
 
 ## Framework-breaking changes — consider twice
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,31 @@ title: Changelog
 
 ### New features
 
+- **Java `record` support — constructor-based field binding** ([#119](https://github.com/jeyben/fixedformat4j/issues/119)) —
+  `@Record` classes can now be Java `record` types (JDK 16+). Annotate the record components
+  directly; `load()` binds all parsed values through the canonical constructor in one call, and
+  `export()` reads through the component accessors. Every annotation — `@Field`, `@Fields`,
+  `@FixedFormatPattern`, `@FixedFormatDecimal`, `@FixedFormatNumber`, `@FixedFormatBoolean`,
+  `@FixedFormatEnum` — applies to record components exactly as to getter methods, including
+  nested `@Record` components, repeating fields (`count > 1`), and `nullChar` / `nullValue`.
+
+  ```java
+  @Record
+  public record CustomerRecord(
+      @Field(offset = 1,  length = 10) String customerId,
+      @Field(offset = 11, length = 20) String customerName) {}
+  ```
+
+  Strictly opt-in by class shape: conventional setter-based classes are processed exactly as
+  before, and the artifact still runs on Java 11 — record binding activates only when a record
+  class is encountered, which by definition requires a JDK 16+ runtime.
+
+  Performance: reflective access to the record API (component discovery, canonical-constructor
+  lookup) happens **once per class** inside the cached metadata build — the same one-time cost
+  the setter path already pays. The per-`load()` hot path performs a single cached
+  `MethodHandle` constructor invoke instead of one invoke per setter; there is no
+  `Method.invoke`-style reflection per record loaded.
+
 - **`@Field.nullValue` — literal null sentinel string** ([#130](https://github.com/jeyben/fixedformat4j/issues/130)) —
   Complement to `nullChar` for feeds where the null marker is a specific **mixed-character**
   string rather than a uniform pad of one character. A slice equal to `nullValue` loads as

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -109,6 +109,21 @@ Key points:
 
 See [Example 6](examples#example-6--field-annotations-and-lombok) for a full worked example including the equivalent plain-POJO style.
 
+## Can I use Java records with fixedformat4j?
+
+Yes, since 1.9.0 (requires a JDK 16+ runtime). Annotate the record components; `load()` binds the parsed values through the canonical constructor — no setters or no-arg constructor needed:
+
+```java
+@Record
+public record EmployeeRecord(
+    @Field(offset = 1, length = 12) String name,
+    @Field(offset = 13, length = 5, align = Align.RIGHT, paddingChar = '0') Integer employeeId,
+    @Field(offset = 18, length = 8) @FixedFormatPattern("yyyyMMdd") LocalDate hireDate,
+    @Field(offset = 26, length = 1) @FixedFormatBoolean(trueValue = "Y", falseValue = "N") Boolean active) {}
+```
+
+All annotations apply to record components exactly as to getter methods. The library artifact itself still runs on Java 11 — record binding only activates when a record class is encountered. There is no extra per-record reflection cost: component discovery happens once per class in the cached metadata build, and each `load()` performs a single cached `MethodHandle` constructor invoke instead of one invoke per setter.
+
 ## Can I apply my own custom formatter?
 
 Yes.

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -13,7 +13,7 @@ Use an instance of `FixedFormatManager` to load and export the data to and from 
 Fixedformat4j requires your Java object to follow these conventions:
 
 1. A class to be used with fixedformat4j must be annotated with `@Record`.
-2. A property is a pair of a getter and a setter method.
+2. A property is a pair of a getter and a setter method — or, since 1.9.0, a component of a Java `record` (JDK 16+).
 3. A `@Field` annotation on a getter (or directly on the field itself, since 1.5.0) tells the manager how to convert to and from string representation.
 
 ### Example
@@ -38,6 +38,20 @@ public class BasicUsageRecord {
 ```
 
 Since 1.5.0, `@Field` can also be placed on the field itself — see [Example 6](../examples#example-6--field-annotations-and-lombok) for the Lombok-friendly style.
+
+### Java records (since 1.9.0)
+
+On JDK 16+ the same mapping can be declared as an immutable Java `record` — annotate the record
+components; `load()` creates the instance through the canonical constructor:
+
+```java
+@Record
+public record BasicUsageRecord(
+    @Field(offset = 1, length = 35) String stringData) {}
+```
+
+All annotations (`@Fields`, `@FixedFormatPattern`, `@FixedFormatDecimal`, `@FixedFormatNumber`,
+`@FixedFormatBoolean`, `@FixedFormatEnum`) apply to record components exactly as to getters.
 
 ## FixedFormatManager
 

--- a/fixedformat4j/pom.xml
+++ b/fixedformat4j/pom.xml
@@ -197,6 +197,41 @@
   </build>
 
   <profiles>
+    <!-- Compiles the additional test sources in src/test/java17 (Java record fixtures need
+         JDK 16+ syntax) whenever the build runs on JDK 17 or newer. The main artifact stays
+         at release 11; on a JDK 11 build this profile is inactive and those tests are skipped. -->
+    <profile>
+      <id>jdk17-tests</id>
+      <activation>
+        <jdk>[17,)</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.testRelease>17</maven.compiler.testRelease>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.6.0</version>
+            <executions>
+              <execution>
+                <id>add-jdk17-test-source</id>
+                <phase>generate-test-sources</phase>
+                <goals>
+                  <goal>add-test-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>src/test/java17</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>release</id>
       <build>

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Record.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/annotation/Record.java
@@ -21,7 +21,12 @@ import java.lang.annotation.Target;
 import java.lang.annotation.ElementType;
 
 /**
- * Marks a class as a representation of a fixed format record
+ * Marks a class as a representation of a fixed format record.
+ *
+ * <p>The annotated class is either a conventional class with a no-arg constructor and
+ * getter/setter pairs, or — since 1.9.0, on a JDK 16+ runtime — a Java {@code record} whose
+ * components carry the {@link Field} annotations; record instances are created through the
+ * canonical constructor.
  *
  * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FixedFormatManager.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FixedFormatManager.java
@@ -29,6 +29,10 @@ public interface FixedFormatManager {
 
   /**
    * Create an instance of the fixedFormatClass and load the data string into the object according to the annotations.
+   * <p>
+   * Conventional classes are instantiated through their no-arg constructor and populated via
+   * setters. Java {@code record} classes (since 1.9.0, JDK 16+) are created in a single
+   * canonical-constructor call after all fields have been parsed.
    *
    * @param clazz the class to instantiate
    * @param data  the data to load

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AnnotationScanner.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/AnnotationScanner.java
@@ -32,15 +32,23 @@ class AnnotationScanner {
    */
   List<AnnotationTarget> scan(Class<?> clazz) {
     LinkedHashMap<String, AnnotationTarget> targets = new LinkedHashMap<>();
+    boolean isJavaRecord = JavaRecordSupport.isJavaRecord(clazz);
 
-    // Pass 1: method annotations
+    // Pass 1: method annotations. Record accessors keep their raw name as key: they carry no
+    // get/is prefix, and stripping would mangle components like 'issuer' to 'suer'.
     for (Method method : clazz.getMethods()) {
       if (method.getAnnotation(Field.class) != null || method.getAnnotation(Fields.class) != null) {
-        targets.put(stripMethodPrefix(method.getName()), AnnotationTarget.ofMethod(method));
+        String key = isJavaRecord ? method.getName() : stripMethodPrefix(method.getName());
+        targets.put(key, AnnotationTarget.ofMethod(method));
       }
     }
 
-    // Pass 2: field annotations — walk class hierarchy
+    // Pass 2: field annotations — walk class hierarchy. Skipped for records: a component
+    // annotation propagates to both the accessor (pass 1 above) and the backing field, so
+    // scanning the fields would only produce duplicates without resolvable get/is getters.
+    if (isJavaRecord) {
+      return new ArrayList<>(targets.values());
+    }
     Class<?> current = clazz;
     while (current != null && current != Object.class) {
       for (java.lang.reflect.Field javaField : current.getDeclaredFields()) {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ClassMetadataCache.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ClassMetadataCache.java
@@ -47,15 +47,38 @@ class ClassMetadataCache {
     this.customRegistry = customRegistry != null ? customRegistry : Collections.emptyMap();
   }
 
-  private final ClassValue<List<FieldDescriptor>> cache = new ClassValue<>() {
+  /** Per-class metadata: the field descriptors plus, for Java records, the constructor binding. */
+  private static final class ClassMetadata {
+    final List<FieldDescriptor> descriptors;
+    final ConstructorBinding constructorBinding;
+
+    ClassMetadata(List<FieldDescriptor> descriptors, ConstructorBinding constructorBinding) {
+      this.descriptors = descriptors;
+      this.constructorBinding = constructorBinding;
+    }
+  }
+
+  private final ClassValue<ClassMetadata> cache = new ClassValue<>() {
     @Override
-    protected List<FieldDescriptor> computeValue(Class<?> clazz) {
-      return build(clazz);
+    protected ClassMetadata computeValue(Class<?> clazz) {
+      List<FieldDescriptor> descriptors = build(clazz);
+      ConstructorBinding binding = JavaRecordSupport.isJavaRecord(clazz)
+          ? ConstructorBinding.forRecord(clazz, descriptors)
+          : null;
+      return new ClassMetadata(descriptors, binding);
     }
   };
 
   List<FieldDescriptor> get(Class<?> clazz) {
-    return cache.get(clazz);
+    return cache.get(clazz).descriptors;
+  }
+
+  /**
+   * Returns the canonical-constructor binding for Java {@code record} classes, or
+   * {@code null} for conventional setter-based classes.
+   */
+  ConstructorBinding constructorBinding(Class<?> clazz) {
+    return cache.get(clazz).constructorBinding;
   }
 
   private List<FieldDescriptor> build(Class<?> clazz) {

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ConstructorBinding.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ConstructorBinding.java
@@ -1,0 +1,116 @@
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Constructor;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.String.format;
+
+/**
+ * Immutable binding of parsed field values to the canonical constructor of a Java
+ * {@code record}: the constructor {@link MethodHandle} plus a precomputed map from each
+ * load {@link FieldDescriptor} to its parameter position (component accessor name equals
+ * canonical-constructor parameter name).
+ *
+ * <p>Built once per record class and cached by {@link ClassMetadataCache}. The
+ * per-{@code load()} cost is one {@code Object[]} allocation and a single constructor
+ * invoke through the handle — the same invocation mechanism the setter path uses.
+ *
+ * <p>A load descriptor with no matching component (e.g. an annotated derived accessor
+ * declared in the record body) is left unmapped and its parsed value is dropped — the same
+ * semantics as a {@code @Field} getter without a setter on a conventional POJO.
+ *
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
+ * @since 1.9.0
+ */
+final class ConstructorBinding {
+
+  private final MethodHandle constructorHandle;
+  private final Object[] defaults;
+  private final Map<FieldDescriptor, Integer> parameterIndexByDescriptor;
+
+  private ConstructorBinding(MethodHandle constructorHandle, Object[] defaults,
+                             Map<FieldDescriptor, Integer> parameterIndexByDescriptor) {
+    this.constructorHandle = constructorHandle;
+    this.defaults = defaults;
+    this.parameterIndexByDescriptor = parameterIndexByDescriptor;
+  }
+
+  static ConstructorBinding forRecord(Class<?> recordClass, List<FieldDescriptor> descriptors) {
+    List<JavaRecordSupport.ComponentInfo> components = JavaRecordSupport.components(recordClass);
+
+    Class<?>[] parameterTypes = new Class<?>[components.size()];
+    Object[] defaults = new Object[components.size()];
+    Map<String, Integer> indexByComponentName = new HashMap<>(components.size() * 2);
+    for (int i = 0; i < components.size(); i++) {
+      JavaRecordSupport.ComponentInfo component = components.get(i);
+      parameterTypes[i] = component.type;
+      defaults[i] = primitiveDefault(component.type);
+      indexByComponentName.put(component.name, i);
+    }
+
+    Map<FieldDescriptor, Integer> parameterIndexByDescriptor = new HashMap<>(descriptors.size() * 2);
+    for (FieldDescriptor desc : descriptors) {
+      Integer index = indexByComponentName.get(desc.target.getter.getName());
+      if (desc.isLoadField && index != null) {
+        parameterIndexByDescriptor.put(desc, index);
+      }
+    }
+
+    return new ConstructorBinding(canonicalConstructorHandle(recordClass, parameterTypes),
+        defaults, parameterIndexByDescriptor);
+  }
+
+  /** Returns a fresh argument array pre-filled with primitive defaults ({@code 0}, {@code false}, …). */
+  Object[] newArgs() {
+    return defaults.clone();
+  }
+
+  /**
+   * Writes a parsed value into the argument slot bound to the given descriptor. A
+   * {@code null} value or an unbound descriptor leaves the slot at its default — mirroring
+   * the setter path, which skips the setter in both cases.
+   */
+  void assign(FieldDescriptor desc, Object value, Object[] args) {
+    Integer index = parameterIndexByDescriptor.get(desc);
+    if (index != null && value != null) {
+      args[index] = value;
+    }
+  }
+
+  Object newInstance(Class<?> recordClass, Object[] args) {
+    try {
+      return constructorHandle.invokeWithArguments(args);
+    } catch (Throwable e) {
+      throw new FixedFormatException(
+          format("unable to create instance of %s through its canonical constructor", recordClass.getName()), e);
+    }
+  }
+
+  private static MethodHandle canonicalConstructorHandle(Class<?> recordClass, Class<?>[] parameterTypes) {
+    try {
+      Constructor<?> canonical = recordClass.getDeclaredConstructor(parameterTypes);
+      return MethodHandles.lookup().unreflectConstructor(canonical);
+    } catch (NoSuchMethodException | IllegalAccessException e) {
+      throw new FixedFormatException(
+          format("unable to access the canonical constructor of %s", recordClass.getName()), e);
+    }
+  }
+
+  private static Object primitiveDefault(Class<?> type) {
+    if (!type.isPrimitive()) return null;
+    if (type == boolean.class) return Boolean.FALSE;
+    if (type == char.class) return (char) 0;
+    if (type == byte.class) return (byte) 0;
+    if (type == short.class) return (short) 0;
+    if (type == int.class) return 0;
+    if (type == long.class) return 0L;
+    if (type == float.class) return 0F;
+    return 0D;
+  }
+}

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
@@ -138,28 +138,20 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
     getAndAssertRecordAnnotation(fixedFormatRecordClass);
     validatePatterns(fixedFormatRecordClass);
 
+    ConstructorBinding constructorBinding = metadataCache.constructorBinding(fixedFormatRecordClass);
+    if (constructorBinding != null) {
+      return loadThroughConstructor(fixedFormatRecordClass, data, constructorBinding);
+    }
+    return loadThroughSetters(fixedFormatRecordClass, data);
+  }
+
+  private <T> T loadThroughSetters(Class<T> fixedFormatRecordClass, String data) {
     T instance = recordInstantiator.instantiate(fixedFormatRecordClass);
 
     for (FieldDescriptor desc : metadataCache.get(fixedFormatRecordClass)) {
       if (!desc.isLoadField) continue;
 
-      Object value;
-      if (desc.isRepeating) {
-        value = repeatingFieldSupport.read(fixedFormatRecordClass, data, desc);
-      } else {
-        String dataToParse = fetchData(data, desc.formatInstructions, desc.context);
-        if (desc.isNestedRecord) {
-          value = load(desc.datatype, dataToParse);
-        } else if (NullSupport.isNullSliceOrValue(dataToParse, desc.formatInstructions)) {
-          value = null;
-        } else {
-          try {
-            value = desc.formatter.parse(dataToParse, desc.formatInstructions);
-          } catch (RuntimeException e) {
-            throw new ParseException(data, dataToParse, fixedFormatRecordClass, desc.target.getter, desc.context, desc.formatInstructions, e);
-          }
-        }
-      }
+      Object value = parseFieldValue(fixedFormatRecordClass, data, desc);
 
       if (value != null && desc.setterHandle != null) {
         try {
@@ -169,13 +161,49 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
               format("could not invoke method %s.%s(%s)", fixedFormatRecordClass.getName(), desc.setter.getName(), desc.datatype), e);
         }
       }
-
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("the loaded data[{}]", value);
-      }
     }
 
     return instance;
+  }
+
+  /**
+   * Java {@code record} path: all field values are parsed first, then the instance is created
+   * in a single canonical-constructor call (records have no setters).
+   */
+  private <T> T loadThroughConstructor(Class<T> fixedFormatRecordClass, String data, ConstructorBinding binding) {
+    Object[] args = binding.newArgs();
+
+    for (FieldDescriptor desc : metadataCache.get(fixedFormatRecordClass)) {
+      if (!desc.isLoadField) continue;
+      binding.assign(desc, parseFieldValue(fixedFormatRecordClass, data, desc), args);
+    }
+
+    return fixedFormatRecordClass.cast(binding.newInstance(fixedFormatRecordClass, args));
+  }
+
+  private Object parseFieldValue(Class<?> fixedFormatRecordClass, String data, FieldDescriptor desc) {
+    Object value;
+    if (desc.isRepeating) {
+      value = repeatingFieldSupport.read(fixedFormatRecordClass, data, desc);
+    } else {
+      String dataToParse = fetchData(data, desc.formatInstructions, desc.context);
+      if (desc.isNestedRecord) {
+        value = load(desc.datatype, dataToParse);
+      } else if (NullSupport.isNullSliceOrValue(dataToParse, desc.formatInstructions)) {
+        value = null;
+      } else {
+        try {
+          value = desc.formatter.parse(dataToParse, desc.formatInstructions);
+        } catch (RuntimeException e) {
+          throw new ParseException(data, dataToParse, fixedFormatRecordClass, desc.target.getter, desc.context, desc.formatInstructions, e);
+        }
+      }
+    }
+
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("the loaded data[{}]", value);
+    }
+    return value;
   }
 
   /**

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FormatInstructionsBuilder.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FormatInstructionsBuilder.java
@@ -64,7 +64,8 @@ class FormatInstructionsBuilder {
   }
 
   Class<?> datatype(Method method, Field fieldAnno) {
-    if (method.getName().startsWith("get") || method.getName().startsWith("is")) {
+    if (method.getName().startsWith("get") || method.getName().startsWith("is")
+        || JavaRecordSupport.isJavaRecord(method.getDeclaringClass())) {
       return method.getReturnType();
     }
     throw new FixedFormatException(format(

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/JavaRecordSupport.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/JavaRecordSupport.java
@@ -1,0 +1,71 @@
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.lang.String.format;
+
+/**
+ * Reflective access to the Java {@code record} API (JDK 16+) from bytecode compiled at
+ * release 11.
+ *
+ * <p>A record class can only be loaded by a JVM that has the record API, so whenever
+ * {@link #isJavaRecord} returns {@code true} the reflective lookups below are guaranteed
+ * to resolve.
+ *
+ * <p>Performance: these lookups run once per record class, inside the
+ * {@link ClassMetadataCache} build (guarded by {@link ClassValue}); the per-{@code load()}
+ * hot path only sees the cached {@link ConstructorBinding}.
+ *
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
+ * @since 1.9.0
+ */
+final class JavaRecordSupport {
+
+  private JavaRecordSupport() {
+  }
+
+  /**
+   * Returns whether the given class is a Java {@code record}. Checked via the superclass
+   * name because {@code java.lang.Record} and {@code Class.isRecord()} are not referenceable
+   * at release 11; the compiler forbids extending {@code java.lang.Record} explicitly, so the
+   * check is equivalent for loadable classes.
+   */
+  static boolean isJavaRecord(Class<?> clazz) {
+    Class<?> superclass = clazz.getSuperclass();
+    return superclass != null && "java.lang.Record".equals(superclass.getName());
+  }
+
+  /** Name and type of one record component, in declaration order. */
+  static final class ComponentInfo {
+    final String name;
+    final Class<?> type;
+
+    ComponentInfo(String name, Class<?> type) {
+      this.name = name;
+      this.type = type;
+    }
+  }
+
+  /**
+   * Returns the record components of the given record class in declaration order — the
+   * exact parameter list of the canonical constructor.
+   */
+  static List<ComponentInfo> components(Class<?> recordClass) {
+    try {
+      Object[] components = (Object[]) Class.class.getMethod("getRecordComponents").invoke(recordClass);
+      List<ComponentInfo> result = new ArrayList<>(components.length);
+      for (Object component : components) {
+        String name = (String) component.getClass().getMethod("getName").invoke(component);
+        Class<?> type = (Class<?>) component.getClass().getMethod("getType").invoke(component);
+        result.add(new ComponentInfo(name, type));
+      }
+      return result;
+    } catch (ReflectiveOperationException e) {
+      throw new FixedFormatException(
+          format("unable to read record components of %s", recordClass.getName()), e);
+    }
+  }
+}

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/MyRecord.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/MyRecord.java
@@ -16,6 +16,9 @@
 package com.ancientprogramming.fixedformat4j.format.impl;
 
 import com.ancientprogramming.fixedformat4j.annotation.*;
+// Explicit import required when test sources compile at release 16+: with only the wildcard
+// import, `Record` is ambiguous against java.lang.Record.
+import com.ancientprogramming.fixedformat4j.annotation.Record;
 
 import java.math.BigDecimal;
 import java.util.Date;

--- a/fixedformat4j/src/test/java17/com/ancientprogramming/fixedformat4j/format/impl/TestFixedFormatManagerJavaRecord.java
+++ b/fixedformat4j/src/test/java17/com/ancientprogramming/fixedformat4j/format/impl/TestFixedFormatManagerJavaRecord.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2004 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.annotation.Align;
+import com.ancientprogramming.fixedformat4j.annotation.EnumFormat;
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.Fields;
+import com.ancientprogramming.fixedformat4j.annotation.FixedFormatBoolean;
+import com.ancientprogramming.fixedformat4j.annotation.FixedFormatDecimal;
+import com.ancientprogramming.fixedformat4j.annotation.FixedFormatEnum;
+import com.ancientprogramming.fixedformat4j.annotation.FixedFormatNumber;
+import com.ancientprogramming.fixedformat4j.annotation.FixedFormatPattern;
+import com.ancientprogramming.fixedformat4j.annotation.Record;
+import com.ancientprogramming.fixedformat4j.annotation.Sign;
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Java {@code record} support — load and export of {@code @Record}-annotated record classes
+ * through the canonical constructor (issue #119).
+ *
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
+ * @since 1.9.0
+ */
+public class TestFixedFormatManagerJavaRecord {
+
+  private final FixedFormatManager manager = FixedFormatManagerImpl.create();
+
+  @Record
+  record BasicRecord(
+      @Field(offset = 1, length = 10) String text,
+      @Field(offset = 11, length = 5, align = Align.RIGHT, paddingChar = '0') Integer amount) {}
+
+  @Test
+  public void loadSimpleRecord() {
+    BasicRecord loaded = manager.load(BasicRecord.class, "some text 00123");
+    assertEquals("some text", loaded.text());
+    assertEquals(123, loaded.amount());
+  }
+
+  @Test
+  public void exportSimpleRecord() {
+    assertEquals("some text 00123", manager.export(new BasicRecord("some text", 123)));
+  }
+
+  @Test
+  public void roundTripUsesRecordValueEquality() {
+    BasicRecord original = new BasicRecord("some text", 123);
+    assertEquals(original, manager.load(BasicRecord.class, manager.export(original)));
+  }
+
+  @Record
+  record PrimitiveRecord(
+      @Field(offset = 1, length = 5, align = Align.RIGHT, paddingChar = '0') int amount,
+      @Field(offset = 6, length = 1) boolean active) {}
+
+  @Test
+  public void primitiveComponentsRoundTrip() {
+    PrimitiveRecord original = new PrimitiveRecord(42, true);
+    String exported = manager.export(original);
+    assertEquals("00042T", exported);
+    assertEquals(original, manager.load(PrimitiveRecord.class, exported));
+  }
+
+  @Record
+  record ExtraConstructorRecord(
+      @Field(offset = 1, length = 10) String name,
+      @Field(offset = 11, length = 5, align = Align.RIGHT, paddingChar = '0') Integer amount) {
+
+    ExtraConstructorRecord(String name) {
+      this(name, -1);
+    }
+  }
+
+  @Test
+  public void loadUsesCanonicalConstructorWhenOthersExist() {
+    ExtraConstructorRecord loaded = manager.load(ExtraConstructorRecord.class, "abc       00007");
+    assertEquals(new ExtraConstructorRecord("abc", 7), loaded);
+  }
+
+  /**
+   * Component names starting with {@code is}/{@code get} must not be mangled by the
+   * getter-prefix-stripping applied to conventional POJO accessors.
+   */
+  @Record
+  record PrefixNamedComponents(
+      @Field(offset = 1, length = 10) String issuer,
+      @Field(offset = 11, length = 10) String getaway) {}
+
+  @Test
+  public void componentNamesStartingWithAccessorPrefixesAreNotMangled() {
+    PrefixNamedComponents original = new PrefixNamedComponents("BANK-0001", "north gate");
+    assertEquals(original, manager.load(PrefixNamedComponents.class, manager.export(original)));
+  }
+
+  @Record
+  record InnerRecord(@Field(offset = 1, length = 5) String code) {}
+
+  @Record
+  record OuterRecord(
+      @Field(offset = 1, length = 5) InnerRecord inner,
+      @Field(offset = 6, length = 5) String name) {}
+
+  @Test
+  public void nestedRecordComponentRoundTrips() {
+    OuterRecord original = new OuterRecord(new InnerRecord("AB123"), "neo");
+    String exported = manager.export(original);
+    assertEquals("AB123neo  ", exported);
+    assertEquals(original, manager.load(OuterRecord.class, exported));
+  }
+
+  @Record
+  record MultiFormatRecord(
+      @Fields({
+          @Field(offset = 1, length = 8),
+          @Field(offset = 9, length = 8)
+      }) String code) {}
+
+  @Test
+  public void multiFormatFieldsLoadFirstAndExportAll() {
+    MultiFormatRecord loaded = manager.load(MultiFormatRecord.class, "ABCDEFGH12345678");
+    assertEquals("ABCDEFGH", loaded.code());
+    assertEquals("ABCDEFGHABCDEFGH", manager.export(new MultiFormatRecord("ABCDEFGH")));
+  }
+
+  @Record
+  record PartiallyAnnotatedRecord(
+      @Field(offset = 1, length = 5) String code,
+      String comment,
+      int revision) {}
+
+  @Test
+  public void unannotatedComponentsGetNullOrPrimitiveDefault() {
+    PartiallyAnnotatedRecord loaded = manager.load(PartiallyAnnotatedRecord.class, "AB123");
+    assertEquals("AB123", loaded.code());
+    assertNull(loaded.comment());
+    assertEquals(0, loaded.revision());
+  }
+
+  record UnannotatedRecord(@Field(offset = 1, length = 5) String code) {}
+
+  @Test
+  public void recordWithoutRecordAnnotationIsRejected() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.load(UnannotatedRecord.class, "AB123"));
+    assertTrue(ex.getMessage().contains("has to be marked with the record annotation"),
+        "unexpected message: " + ex.getMessage());
+  }
+
+  @Record
+  record RepeatingFieldRecord(
+      @Field(offset = 1, length = 3, count = 3, align = Align.RIGHT, paddingChar = '0') List<Integer> values) {}
+
+  @Test
+  public void repeatingFieldComponentRoundTrips() {
+    RepeatingFieldRecord original = new RepeatingFieldRecord(List.of(1, 2, 3));
+    String exported = manager.export(original);
+    assertEquals("001002003", exported);
+    assertEquals(original, manager.load(RepeatingFieldRecord.class, exported));
+  }
+
+  @Record
+  record NullableComponentRecord(
+      @Field(offset = 1, length = 5, align = Align.RIGHT, paddingChar = '0', nullChar = '?') Integer count,
+      @Field(offset = 6, length = 4, align = Align.RIGHT, paddingChar = '0', nullValue = "9998") Integer rate) {}
+
+  @Test
+  public void nullCharAndNullValueComponentsRoundTripNull() {
+    NullableComponentRecord original = new NullableComponentRecord(null, null);
+    String exported = manager.export(original);
+    assertEquals("?????9998", exported);
+    assertEquals(original, manager.load(NullableComponentRecord.class, exported));
+  }
+
+  @Test
+  public void nullCharAndNullValueComponentsRoundTripValues() {
+    NullableComponentRecord original = new NullableComponentRecord(12, 34);
+    String exported = manager.export(original);
+    assertEquals("000120034", exported);
+    assertEquals(original, manager.load(NullableComponentRecord.class, exported));
+  }
+
+  enum Status { ACTIVE, CLOSED }
+
+  /** Every supplementary annotation must apply to record components, exactly as on POJO getters. */
+  @Record
+  record SupplementaryAnnotationsRecord(
+      @Field(offset = 1, length = 8) @FixedFormatPattern("yyyyMMdd") LocalDate date,
+      @Field(offset = 9, length = 10, align = Align.RIGHT, paddingChar = '0') @FixedFormatDecimal(decimals = 2) BigDecimal price,
+      @Field(offset = 19, length = 5, align = Align.RIGHT, paddingChar = '0') @FixedFormatNumber(sign = Sign.PREPEND) Integer delta,
+      @Field(offset = 24, length = 1) @FixedFormatBoolean(trueValue = "Y", falseValue = "N") Boolean active,
+      @Field(offset = 25, length = 6) @FixedFormatEnum(EnumFormat.LITERAL) Status status) {}
+
+  @Test
+  public void supplementaryAnnotationsApplyToRecordComponents() {
+    SupplementaryAnnotationsRecord original = new SupplementaryAnnotationsRecord(
+        LocalDate.of(2026, 4, 5), new BigDecimal("50.10"), -12, true, Status.CLOSED);
+
+    String exported = manager.export(original);
+    assertEquals("20260405" + "0000005010" + "-0012" + "Y" + "CLOSED", exported);
+
+    SupplementaryAnnotationsRecord loaded = manager.load(SupplementaryAnnotationsRecord.class, exported);
+    assertEquals(LocalDate.of(2026, 4, 5), loaded.date());
+    assertEquals(0, new BigDecimal("50.10").compareTo(loaded.price()));
+    assertEquals(-12, loaded.delta());
+    assertEquals(true, loaded.active());
+    assertEquals(Status.CLOSED, loaded.status());
+  }
+}


### PR DESCRIPTION
Closes #119 (Phase 1 — Java `record` support; Phase 2, `@FixedFormatConstructor` for pre-16 immutable POJOs, stays in the issue as follow-up).

## Summary

`@Record` classes can now be Java `record` types (JDK 16+):

```java
@Record
public record CustomerRecord(
    @Field(offset = 1,  length = 10) String customerId,
    @Field(offset = 11, length = 20) String customerName) {}
```

- Annotations on record components propagate to the accessors (all ff4j annotations are `@Target({METHOD, FIELD})`, so no annotation-surface change was needed).
- `load()` parses all fields first, then creates the instance in **one canonical-constructor call**; `export()` reads through the component accessors with zero logic changes.
- Mechanism is **reflection, not a multi-release JAR**: the artifact stays compiled at release 11; record detection uses the superclass name (`java.lang.Record`) and component discovery calls `Class.getRecordComponents()` reflectively. A record class can only be loaded by a 16+ JVM, so the path is unreachable elsewhere.

### Implementation

- **`JavaRecordSupport`** (new, package-private) — reflective record detection and component discovery; runs once per class inside the `ClassValue`-cached metadata build.
- **`ConstructorBinding`** (new, package-private) — cached canonical-constructor `MethodHandle` + load-descriptor→parameter mapping; `null` parses keep primitive defaults, mirroring setter-skip semantics.
- **`AnnotationScanner`** — field pass skipped for records (component annotations already propagate to accessors); raw accessor names as map keys so components like `issuer` aren't `is`-prefix-mangled.
- **`FixedFormatManagerImpl`** — `load()` split into the byte-for-byte unchanged setter path and the record constructor path, sharing one extracted `parseFieldValue` helper.
- **`FormatInstructionsBuilder`** — record accessors exempt from the `get`/`is` prefix requirement.
- **Build/CI** — `jdk17-tests` Maven profile auto-activates on JDK 17+ and compiles `src/test/java17` at release 17 (main artifact stays release 11); new JDK 17 CI job alongside the existing Java 11 compatibility gate.

### Performance

Reflective record-API access happens **once per class** in the cached metadata build — the same one-time cost the setter path already pays. The per-`load()` hot path is a single cached `MethodHandle` constructor invoke + one `Object[]` allocation, vs one invoke per setter for an equivalent POJO. No `Method.invoke`-style reflection per record loaded. Documented in the changelog, FAQ, and `JavaRecordSupport` Javadoc.

## Breaking-change checklist

- **What breaks:** nothing. Java records previously **always** failed — `load()` with `FixedFormatException` ("missing a default constructor"; records cannot have one) and `export()` with "No getter found" — so every behavioral change is error → success. All inputs that previously produced a result produce the identical result.
- **Who's affected:** only consumers passing `record` classes (previously impossible). Annotation surface, `FixedFormatManager`, `FixedFormatter<T>`, and all `Abstract*Formatter` extension points unchanged. `RecordInstantiator`, `AnnotationScanner`, `ClassMetadataCache`, `FieldDescriptor` are package-private internals.
- **Activation gate:** superclass `== java.lang.Record` — unreachable for hand-written classes (the compiler forbids extending `java.lang.Record` explicitly).
- **Round-trip impact:** `load(export(x)) == x` unchanged for all existing classes; asserted for Java records via record value equality.
- **Migration/deprecation path:** none needed — purely additive, opt-in by class shape.
- **Version classification:** minor → fits `1.9.0-SNAPSHOT`.

## Testing

- 14 new behavior tests in `src/test/java17/.../TestFixedFormatManagerJavaRecord.java` (written RED-first), covering load/export/round-trip, primitive components, canonical vs extra constructors, accessor-prefix-named components, nested records, `@Fields`, un-annotated components, repeating fields, `nullChar`/`nullValue`, and **every supplementary annotation on record components** (`@FixedFormatPattern`, `@FixedFormatDecimal`, `@FixedFormatNumber`, `@FixedFormatBoolean`, `@FixedFormatEnum`).
- JDK 11: `mvn install` — 946 tests green, record tests correctly excluded, artifact builds at release 11.
- JDK 25 (locally; CI uses 17): full suite + 14 record tests green.
- One pre-existing fixture (`MyRecord.java`) gained an explicit `Record` import — at release 16+ the wildcard annotation import is ambiguous against `java.lang.Record`.
- Mutation testing: GitHub Actions PIT pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)