### PR TITLE
feat: FixedFormatIntrospector — schema introspection API (#117)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,8 @@ The library maps Java POJOs annotated with `@Record` and `@Field` to/from fixed-
 - `load(Class<T>, String data)` — parses a fixed-width string into a new instance of the annotated class
 - `export(T instance)` / `export(String template, T instance)` — serializes an annotated instance to a fixed-width string
 
+`FixedFormatManagerImpl` additionally implements `FixedFormatIntrospector` (since 1.9.0): `introspect(Class<?>)` exposes the field layout as public immutable `FieldInfo` descriptors, ordered by offset. The interface is deliberately separate from `FixedFormatManager` (ISP; keeps third-party manager implementations compatible).
+
 **Annotation layer** (`annotation/` package):
 - `@Record` — marks a class as a fixed-format record; declares total length and padding char
 - `@Field` — placed on getter methods (or record components, since 1.9.0); declares `offset` (1-based), `length`, `align`, `paddingChar`, and optional `formatter`

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Full documentation is available at **https://jeyben.github.io/fixedformat4j/**:
 - [File Processing](https://jeyben.github.io/fixedformat4j/usage/file-processing) — reading files and streams with `FixedFormatReader`
 - [Nested Records](https://jeyben.github.io/fixedformat4j/usage/nested-records) — embedding one record inside another
 - [Compile-time Validation](https://jeyben.github.io/fixedformat4j/usage/compile-time-validation) — optional `fixedformat4j-processor` artifact that turns `@Field`/`@Record` misconfigurations into `javac` errors
+- [Schema Introspection](https://jeyben.github.io/fixedformat4j/usage/introspection) — query the field layout of a `@Record` class at runtime via `FixedFormatIntrospector`
 - [FAQ](https://jeyben.github.io/fixedformat4j/faq)
 - [Changelog](https://jeyben.github.io/fixedformat4j/changelog)
 

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -13,6 +13,8 @@
       url: /usage/file-processing
     - title: Compile-time Validation
       url: /usage/compile-time-validation
+    - title: Schema Introspection
+      url: /usage/introspection
 - title: Examples
   url: /examples
 - title: Get It

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,22 @@ title: Changelog
 
 ### New features
 
+- **Schema introspection API — `FixedFormatIntrospector`** ([#117](https://github.com/jeyben/fixedformat4j/issues/117)) —
+  query the field layout of a `@Record` class at runtime. `FixedFormatManagerImpl` now also
+  implements the new narrow `FixedFormatIntrospector` interface, whose `introspect(Class<?>)`
+  returns one immutable `FieldInfo` per effective `@Field` (ordered by offset): property name,
+  offset, length, data type, resolved alignment, padding char, `nullChar`/`nullValue` sentinels,
+  formatter class, repeat count, and nested-record flag. Intended for documentation generators,
+  UI form builders, format-drift detection, and layout assertions in tests — see
+  [Schema introspection](usage/introspection).
+
+  Delivered as a separate interface rather than an addition to `FixedFormatManager`, so existing
+  third-party manager implementations remain source and binary compatible.
+
+  Performance: `introspect()` reuses the same cached per-class metadata as `load()`/`export()`
+  (scan and validation run once per class); each call performs only an O(fields) mapping with no
+  I/O. It triggers the same validation as `load()`, so it doubles as a startup preflight check.
+
 - **Compile-time annotation validation — new optional `fixedformat4j-processor` artifact**
   ([#118](https://github.com/jeyben/fixedformat4j/issues/118)) —
   an annotation processor that validates `@Field` / `@Record` configuration during `javac`, so

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -83,6 +83,13 @@ See the [File Processing](file-processing) page for the full guide including mul
 
 Annotations instruct the manager on how to load and export data. See the [complete annotations reference](annotations).
 
+## Schema introspection
+
+Since 1.9.0 the `FixedFormatIntrospector` interface (implemented by `FixedFormatManagerImpl`)
+exposes the field layout of a `@Record` class as immutable `FieldInfo` descriptors — for
+documentation generators, UI builders, and layout assertions. See
+[Schema introspection](introspection).
+
 ## Compile-time validation
 
 Since 1.9.0 the optional `fixedformat4j-processor` artifact turns annotation misconfigurations

--- a/docs/usage/introspection.md
+++ b/docs/usage/introspection.md
@@ -1,0 +1,59 @@
+---
+title: Schema introspection
+---
+
+# Schema introspection
+
+Since 1.9.0 the field layout of a `@Record` class can be queried at runtime through the
+`FixedFormatIntrospector` interface, implemented by `FixedFormatManagerImpl`. This serves
+tooling built on top of the annotated schema — documentation generators, UI form builders,
+format negotiation (detecting offset/length drift between record class versions), and layout
+assertions in tests — without re-implementing annotation scanning.
+
+```java
+FixedFormatIntrospector introspector = new FixedFormatManagerImpl();
+
+for (FieldInfo field : introspector.introspect(CustomerRecord.class)) {
+  System.out.printf("%-15s offset=%2d length=%2d type=%s%n",
+      field.getPropertyName(), field.getOffset(), field.getLength(),
+      field.getDataType().getSimpleName());
+}
+```
+
+```
+customerId      offset= 1 length=10 type=String
+customerName    offset=11 length=20 type=String
+```
+
+`FixedFormatIntrospector` is a separate interface rather than an addition to
+`FixedFormatManager`, so existing third-party manager implementations stay source and binary
+compatible; callers that only need schema access can depend on the narrow contract.
+
+## FieldInfo
+
+`introspect()` returns one immutable `FieldInfo` per effective `@Field`, ordered by offset.
+A getter carrying `@Fields` contributes one entry per inner `@Field`.
+
+| Accessor | Meaning |
+|---|---|
+| `getPropertyName()` | Bean-style property name (`getCustomerId()` → `customerId`); for Java records, the component name as-is |
+| `getOffset()` / `getLength()` | 1-based offset; length `-1` = rest-of-line |
+| `getDataType()` | Declared Java type (the collection/array type for repeating fields) |
+| `getEffectiveAlignment()` | Resolved `LEFT`/`RIGHT` — record-level defaults already applied, never `INHERIT` |
+| `getPaddingChar()` | Padding character |
+| `getNullChar()` / `getNullValue()` | Null sentinels (`UNSET_NULL_CHAR` / `""` when not configured) |
+| `getFormatterClass()` | Configured formatter (`ByTypeFormatter` unless overridden) |
+| `getRepeatCount()` | `count` attribute; `1` for non-repeating fields |
+| `isNestedRecord()` | `true` when the field type is itself a `@Record` class |
+
+## Validation preflight
+
+`introspect()` triggers the same one-time metadata build and annotation validation as
+`load()`/`export()`, so it doubles as a startup preflight check: an invalid configuration
+(bad date pattern, enum too wide, misconfigured null sentinel, …) throws
+`FixedFormatException` at introspection time. For build-time validation, see
+[Compile-time validation](compile-time-validation).
+
+Performance: the underlying scan and validation run **once per class** (the same cached
+metadata used by `load()`/`export()`); each `introspect()` call performs only an
+O(number of fields) mapping with no I/O and no reflection beyond the cached metadata.

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FieldInfo.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FieldInfo.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2004 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ancientprogramming.fixedformat4j.format;
+
+import com.ancientprogramming.fixedformat4j.annotation.Align;
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+
+/**
+ * Immutable description of one {@code @Field} of a record class, as returned by
+ * {@link FixedFormatIntrospector#introspect(Class)}.
+ *
+ * <p>All values are fully resolved: {@link #getEffectiveAlignment()} is never
+ * {@link Align#INHERIT} — record-level alignment defaults have already been applied.
+ *
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
+ * @since 1.9.0
+ */
+public final class FieldInfo {
+
+  private final String propertyName;
+  private final int offset;
+  private final int length;
+  private final Class<?> dataType;
+  private final Align effectiveAlignment;
+  private final char paddingChar;
+  private final char nullChar;
+  private final String nullValue;
+  private final Class<? extends FixedFormatter<?>> formatterClass;
+  private final int repeatCount;
+  private final boolean nestedRecord;
+
+  public FieldInfo(
+      String propertyName,
+      int offset,
+      int length,
+      Class<?> dataType,
+      Align effectiveAlignment,
+      char paddingChar,
+      char nullChar,
+      String nullValue,
+      Class<? extends FixedFormatter<?>> formatterClass,
+      int repeatCount,
+      boolean nestedRecord) {
+    this.propertyName = propertyName;
+    this.offset = offset;
+    this.length = length;
+    this.dataType = dataType;
+    this.effectiveAlignment = effectiveAlignment;
+    this.paddingChar = paddingChar;
+    this.nullChar = nullChar;
+    this.nullValue = nullValue;
+    this.formatterClass = formatterClass;
+    this.repeatCount = repeatCount;
+    this.nestedRecord = nestedRecord;
+  }
+
+  /**
+   * @return the bean-style property name, e.g. {@code "customerId"} for {@code getCustomerId()};
+   *         for Java record classes the component name as-is
+   */
+  public String getPropertyName() {
+    return propertyName;
+  }
+
+  /** @return the 1-based offset of the field within the record */
+  public int getOffset() {
+    return offset;
+  }
+
+  /** @return the field length in characters, or {@link Field#REST_OF_LINE} ({@code -1}) */
+  public int getLength() {
+    return length;
+  }
+
+  /** @return the declared Java type of the property (the collection/array type for repeating fields) */
+  public Class<?> getDataType() {
+    return dataType;
+  }
+
+  /** @return the resolved alignment — {@link Align#LEFT} or {@link Align#RIGHT}, never {@link Align#INHERIT} */
+  public Align getEffectiveAlignment() {
+    return effectiveAlignment;
+  }
+
+  /** @return the padding character */
+  public char getPaddingChar() {
+    return paddingChar;
+  }
+
+  /** @return the null sentinel character, or {@link Field#UNSET_NULL_CHAR} when not configured */
+  public char getNullChar() {
+    return nullChar;
+  }
+
+  /** @return the literal null sentinel string, or the empty string when not configured */
+  public String getNullValue() {
+    return nullValue;
+  }
+
+  /** @return the configured formatter class ({@code ByTypeFormatter} when not overridden) */
+  public Class<? extends FixedFormatter<?>> getFormatterClass() {
+    return formatterClass;
+  }
+
+  /** @return the repetition count; {@code 1} for non-repeating fields */
+  public int getRepeatCount() {
+    return repeatCount;
+  }
+
+  /** @return {@code true} when the field's type is itself a {@code @Record} class loaded recursively */
+  public boolean isNestedRecord() {
+    return nestedRecord;
+  }
+
+  @Override
+  public String toString() {
+    return "FieldInfo{" + propertyName + " offset=" + offset + " length=" + length
+        + " type=" + dataType.getName() + "}";
+  }
+}

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FixedFormatIntrospector.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/FixedFormatIntrospector.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2004 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ancientprogramming.fixedformat4j.format;
+
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+
+import java.util.List;
+
+/**
+ * Read-only access to the field layout of a {@code @Record} class.
+ *
+ * <p>Intended for tooling built on top of the annotated schema: documentation generators,
+ * UI form builders, format negotiation (detecting offset/length drift between record class
+ * versions), and layout assertions in tests.
+ *
+ * <p>This is a separate interface rather than part of {@link FixedFormatManager} so that
+ * existing third-party {@code FixedFormatManager} implementations remain source and binary
+ * compatible, and so callers that only need schema access can depend on this narrow contract.
+ * {@code FixedFormatManagerImpl} implements both.
+ *
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
+ * @since 1.9.0
+ */
+public interface FixedFormatIntrospector {
+
+  /**
+   * Returns one {@link FieldInfo} per effective {@code @Field} annotation of the given record
+   * class, ordered by {@link FieldInfo#getOffset() offset}. A getter carrying {@code @Fields}
+   * contributes one entry per inner {@code @Field}.
+   *
+   * <p>Calling this method triggers the same one-time metadata build and annotation validation
+   * that {@code load()} / {@code export()} trigger, so it is safe to use as a configuration
+   * preflight check at application startup. The returned list is rebuilt on each call from the
+   * cached metadata (an O(number of fields) mapping with no I/O); the underlying scan and
+   * validation run only once per class.
+   *
+   * @param clazz the {@code @Record}-annotated class to introspect
+   * @return an immutable list of field descriptors ordered by offset; never {@code null}
+   * @throws FixedFormatException if {@code clazz} is not annotated with {@code @Record} or its
+   *                              annotation configuration is invalid
+   */
+  List<FieldInfo> introspect(Class<?> clazz);
+}

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
@@ -17,6 +17,8 @@ package com.ancientprogramming.fixedformat4j.format.impl;
 
 import com.ancientprogramming.fixedformat4j.annotation.Record;
 import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+import com.ancientprogramming.fixedformat4j.format.FieldInfo;
+import com.ancientprogramming.fixedformat4j.format.FixedFormatIntrospector;
 import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
 import com.ancientprogramming.fixedformat4j.format.FixedFormatter;
 import com.ancientprogramming.fixedformat4j.format.ParseException;
@@ -39,7 +41,7 @@ import static java.lang.String.format;
  * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.0.0
  */
-public class FixedFormatManagerImpl implements FixedFormatManager {
+public class FixedFormatManagerImpl implements FixedFormatManager, FixedFormatIntrospector {
 
   private static final Logger LOG = LoggerFactory.getLogger(FixedFormatManagerImpl.class);
 
@@ -271,6 +273,43 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
 
   private void validatePatterns(Class<?> recordClass) {
     validatedClasses.get(recordClass);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public List<FieldInfo> introspect(Class<?> clazz) {
+    getAndAssertRecordAnnotation(clazz);
+    validatePatterns(clazz);
+
+    boolean isJavaRecord = JavaRecordSupport.isJavaRecord(clazz);
+    AnnotationScanner scanner = new AnnotationScanner();
+    List<FieldInfo> result = new java.util.ArrayList<>();
+    for (FieldDescriptor desc : metadataCache.get(clazz)) {
+      result.add(new FieldInfo(
+          propertyName(desc, isJavaRecord, scanner),
+          desc.fieldAnnotation.offset(),
+          desc.fieldAnnotation.length(),
+          desc.datatype,
+          desc.formatInstructions.getAlignment(),
+          desc.fieldAnnotation.paddingChar(),
+          desc.fieldAnnotation.nullChar(),
+          desc.fieldAnnotation.nullValue(),
+          desc.fieldAnnotation.formatter(),
+          desc.fieldAnnotation.count(),
+          desc.isNestedRecord));
+    }
+    result.sort(java.util.Comparator.comparingInt(FieldInfo::getOffset));
+    return List.copyOf(result);
+  }
+
+  private String propertyName(FieldDescriptor desc, boolean isJavaRecord, AnnotationScanner scanner) {
+    String getterName = desc.target.getter.getName();
+    if (isJavaRecord) {
+      return getterName;
+    }
+    String stripped = scanner.stripMethodPrefix(getterName);
+    return Character.toLowerCase(stripped.charAt(0)) + stripped.substring(1);
   }
 
   private static void appendData(StringBuilder result, char paddingChar, int offset, String data) {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestIntrospection.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestIntrospection.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2004 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.annotation.Align;
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+import com.ancientprogramming.fixedformat4j.format.FieldInfo;
+import com.ancientprogramming.fixedformat4j.format.FixedFormatIntrospector;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The introspection API exposes the field layout of a {@code @Record} class as immutable
+ * {@link FieldInfo} descriptors, so documentation generators and format-drift tooling can query
+ * the schema instead of re-implementing annotation scanning.
+ */
+class TestIntrospection {
+
+  private final FixedFormatIntrospector introspector = new FixedFormatManagerImpl();
+
+  @com.ancientprogramming.fixedformat4j.annotation.Record
+  public static class BasicRecord {
+
+    @Field(offset = 1, length = 10)
+    public String getCustomerId() {
+      return null;
+    }
+
+    public void setCustomerId(String value) {
+    }
+
+    @Field(offset = 11, length = 5)
+    public Integer getAmount() {
+      return null;
+    }
+
+    public void setAmount(Integer value) {
+    }
+  }
+
+  @Test
+  void exposesPropertyNameOffsetLengthAndDataTypePerField() {
+    List<FieldInfo> fields = introspector.introspect(BasicRecord.class);
+
+    assertEquals(2, fields.size());
+
+    FieldInfo customerId = fields.get(0);
+    assertEquals("customerId", customerId.getPropertyName());
+    assertEquals(1, customerId.getOffset());
+    assertEquals(10, customerId.getLength());
+    assertEquals(String.class, customerId.getDataType());
+
+    FieldInfo amount = fields.get(1);
+    assertEquals("amount", amount.getPropertyName());
+    assertEquals(11, amount.getOffset());
+    assertEquals(5, amount.getLength());
+    assertEquals(Integer.class, amount.getDataType());
+  }
+
+  @Test
+  void defaultsAreReflectedInFieldInfo() {
+    FieldInfo customerId = introspector.introspect(BasicRecord.class).get(0);
+
+    assertEquals(Align.LEFT, customerId.getEffectiveAlignment());
+    assertEquals(' ', customerId.getPaddingChar());
+    assertEquals(Field.UNSET_NULL_CHAR, customerId.getNullChar());
+    assertEquals("", customerId.getNullValue());
+    assertEquals(1, customerId.getRepeatCount());
+    assertEquals(false, customerId.isNestedRecord());
+  }
+
+  @Test
+  void nonRecordClassIsRejected() {
+    assertThrows(FixedFormatException.class, () -> introspector.introspect(String.class));
+  }
+}

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestIntrospection.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/format/impl/TestIntrospection.java
@@ -91,4 +91,138 @@ class TestIntrospection {
   void nonRecordClassIsRejected() {
     assertThrows(FixedFormatException.class, () -> introspector.introspect(String.class));
   }
+
+  @com.ancientprogramming.fixedformat4j.annotation.Record(align = com.ancientprogramming.fixedformat4j.annotation.RecordAlign.RIGHT)
+  public static class RightAlignedRecord {
+
+    @Field(offset = 1, length = 8)
+    public String getInherited() {
+      return null;
+    }
+
+    public void setInherited(String value) {
+    }
+
+    @Field(offset = 9, length = 8, align = Align.LEFT)
+    public String getOverridden() {
+      return null;
+    }
+
+    public void setOverridden(String value) {
+    }
+  }
+
+  @Test
+  void effectiveAlignmentResolvesRecordDefaultAndFieldOverride() {
+    List<FieldInfo> fields = introspector.introspect(RightAlignedRecord.class);
+
+    assertEquals(Align.RIGHT, fields.get(0).getEffectiveAlignment(),
+        "field without explicit align inherits @Record(align = RIGHT)");
+    assertEquals(Align.LEFT, fields.get(1).getEffectiveAlignment(),
+        "explicit @Field(align) overrides the record default");
+  }
+
+  @com.ancientprogramming.fixedformat4j.annotation.Record
+  public static class ConfiguredRecord {
+
+    @Field(offset = 1, length = 6, paddingChar = '0', nullValue = "999999")
+    public Integer getAmount() {
+      return null;
+    }
+
+    public void setAmount(Integer value) {
+    }
+
+    @Field(offset = 7, length = 4, nullChar = ' ',
+        formatter = com.ancientprogramming.fixedformat4j.format.impl.StringFormatter.class)
+    public String getCode() {
+      return null;
+    }
+
+    public void setCode(String value) {
+    }
+
+    @Field(offset = 11, length = 3, count = 4)
+    public List<String> getTags() {
+      return null;
+    }
+
+    public void setTags(List<String> value) {
+    }
+
+    @Field(offset = 23, length = 10)
+    public BasicRecord getNested() {
+      return null;
+    }
+
+    public void setNested(BasicRecord value) {
+    }
+  }
+
+  @Test
+  void sentinelsFormatterRepeatCountAndNestedRecordAreExposed() {
+    List<FieldInfo> fields = introspector.introspect(ConfiguredRecord.class);
+
+    FieldInfo amount = fields.get(0);
+    assertEquals('0', amount.getPaddingChar());
+    assertEquals("999999", amount.getNullValue());
+
+    FieldInfo code = fields.get(1);
+    assertEquals(' ', code.getNullChar());
+    assertEquals(StringFormatter.class, code.getFormatterClass());
+
+    FieldInfo tags = fields.get(2);
+    assertEquals(4, tags.getRepeatCount());
+    assertEquals(List.class, tags.getDataType());
+
+    FieldInfo nested = fields.get(3);
+    assertEquals(true, nested.isNestedRecord());
+    assertEquals(BasicRecord.class, nested.getDataType());
+  }
+
+  @com.ancientprogramming.fixedformat4j.annotation.Record
+  public static class MultiFormatRecord {
+
+    @com.ancientprogramming.fixedformat4j.annotation.Fields({
+        @Field(offset = 1, length = 10),
+        @Field(offset = 11, length = 10, align = Align.RIGHT, paddingChar = '0')
+    })
+    public String getValue() {
+      return null;
+    }
+
+    public void setValue(String value) {
+    }
+  }
+
+  @Test
+  void fieldsAnnotationYieldsOneFieldInfoPerInnerField() {
+    List<FieldInfo> fields = introspector.introspect(MultiFormatRecord.class);
+
+    assertEquals(2, fields.size());
+    assertEquals("value", fields.get(0).getPropertyName());
+    assertEquals("value", fields.get(1).getPropertyName());
+    assertEquals(1, fields.get(0).getOffset());
+    assertEquals(11, fields.get(1).getOffset());
+    assertEquals('0', fields.get(1).getPaddingChar());
+    assertEquals(Align.RIGHT, fields.get(1).getEffectiveAlignment());
+  }
+
+  @com.ancientprogramming.fixedformat4j.annotation.Record
+  public static class BadPatternRecord {
+
+    @Field(offset = 1, length = 18)
+    @com.ancientprogramming.fixedformat4j.annotation.FixedFormatPattern("not-a-date-pattern")
+    public java.util.Date getCreatedAt() {
+      return null;
+    }
+
+    public void setCreatedAt(java.util.Date value) {
+    }
+  }
+
+  @Test
+  void invalidConfigurationFailsAtIntrospectTimeAsAPreflightCheck() {
+    assertThrows(FixedFormatException.class, () -> introspector.introspect(BadPatternRecord.class));
+  }
 }

--- a/fixedformat4j/src/test/java17/com/ancientprogramming/fixedformat4j/format/impl/TestIntrospectionJavaRecord.java
+++ b/fixedformat4j/src/test/java17/com/ancientprogramming/fixedformat4j/format/impl/TestIntrospectionJavaRecord.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2004 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ancientprogramming.fixedformat4j.format.impl;
+
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.Record;
+import com.ancientprogramming.fixedformat4j.format.FieldInfo;
+import com.ancientprogramming.fixedformat4j.format.FixedFormatIntrospector;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Introspection of Java {@code record} classes: property names are the component names as-is
+ * (no get/is prefix to strip — and stripping would mangle components like {@code issuer}).
+ *
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
+ * @since 1.9.0
+ */
+public class TestIntrospectionJavaRecord {
+
+  private final FixedFormatIntrospector introspector = new FixedFormatManagerImpl();
+
+  @Record
+  record CustomerRecord(
+      @Field(offset = 1, length = 10) String customerId,
+      @Field(offset = 11, length = 20) String issuer) {}
+
+  @Test
+  public void recordComponentNamesAreExposedVerbatim() {
+    List<FieldInfo> fields = introspector.introspect(CustomerRecord.class);
+
+    assertEquals(2, fields.size());
+    assertEquals("customerId", fields.get(0).getPropertyName());
+    assertEquals(String.class, fields.get(0).getDataType());
+    assertEquals("issuer", fields.get(1).getPropertyName());
+    assertEquals(11, fields.get(1).getOffset());
+    assertEquals(20, fields.get(1).getLength());
+  }
+}


### PR DESCRIPTION
## Summary

Implements issue #117: a public, read-only view of a `@Record` class's field layout for documentation generators, UI form builders, format-drift detection, and layout assertions in tests.

```java
FixedFormatIntrospector introspector = new FixedFormatManagerImpl();
List<FieldInfo> fields = introspector.introspect(CustomerRecord.class);
```

## Design

- **New narrow interface `FixedFormatIntrospector`** — the issue's preferred (ISP-compliant) option. `FixedFormatManager` is **not touched**, so third-party manager implementations stay source and binary compatible.
- **`FieldInfo`** — public immutable value type: property name, offset, length (`-1` = rest-of-line), data type, resolved alignment (record-level `RecordAlign` inheritance and field overrides applied — never `INHERIT`), padding char, `nullChar`/`nullValue` sentinels, formatter class, repeat count, nested-record flag. `nullValue` extends the issue's sketch (which predates 1.9.0's `nullValue`) to complete the null-sentinel pair.
- **Mapping** — `FixedFormatManagerImpl.introspect()` asserts `@Record`, runs the same validation preflight as `load()`/`export()`, and maps the instance's cached `FieldDescriptor`s (respecting custom type registries from the 1.9.0 builder). One `FieldInfo` per effective `@Field`, so `@Fields` getters yield several entries.
- **Ordering contract: by offset** — `Class.getMethods()` order is unspecified, so declaration order is not reproducible; offset order is deterministic and what layout tooling wants.
- Java record components expose their names verbatim (`issuer` stays `issuer`); POJO getters are bean-decapitalized (`getCustomerId` → `customerId`).

## Compatibility

**Minor (1.9.0), non-breaking.** Framework-breaking checklist: **N/A — purely additive**: two new public types, one additional interface on `FixedFormatManagerImpl`. No annotation attributes, existing interfaces, extension points, activation gates, or parse/export semantics change.

## Performance

`introspect()` reuses the per-class cached metadata (scan + validation run once per class, exactly as `load()`/`export()`); each call is an O(fields) mapping with no I/O. Doubles as a startup preflight check — invalid configurations throw `FixedFormatException` at introspect time.

## Tests

8 behavior tests (7 + 1 in the JDK 17+ source set): basic facets, alignment resolution, sentinels/formatter/repeat/nested flags, `@Fields` expansion, non-`@Record` rejection, validation preflight, record component names. Full reactor green on JDK 11 and JDK 25.

## Docs

New `docs/usage/introspection.md` + nav/index links, changelog `[Unreleased]` entry incl. perf note, README link, CLAUDE.md architecture note.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)