### PR TITLE
feat: fixedformat4j-micrometer — Micrometer instrumentation module (#120)

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -95,7 +95,7 @@ jobs:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: mvn -B deploy -pl fixedformat4j,fixedformat4j-processor -DskipTests --no-transfer-progress -P release
+        run: mvn -B deploy -pl fixedformat4j,fixedformat4j-processor,fixedformat4j-micrometer -DskipTests --no-transfer-progress -P release
 
       - name: Upload release artifacts to GitHub
         if: github.event_name == 'release'
@@ -108,7 +108,10 @@ jobs:
             fixedformat4j/target/fixedformat4j-${{ env.RELEASE_VERSION }}-javadoc.jar \
             fixedformat4j-processor/target/fixedformat4j-processor-${{ env.RELEASE_VERSION }}.jar \
             fixedformat4j-processor/target/fixedformat4j-processor-${{ env.RELEASE_VERSION }}-sources.jar \
-            fixedformat4j-processor/target/fixedformat4j-processor-${{ env.RELEASE_VERSION }}-javadoc.jar
+            fixedformat4j-processor/target/fixedformat4j-processor-${{ env.RELEASE_VERSION }}-javadoc.jar \
+            fixedformat4j-micrometer/target/fixedformat4j-micrometer-${{ env.RELEASE_VERSION }}.jar \
+            fixedformat4j-micrometer/target/fixedformat4j-micrometer-${{ env.RELEASE_VERSION }}-sources.jar \
+            fixedformat4j-micrometer/target/fixedformat4j-micrometer-${{ env.RELEASE_VERSION }}-javadoc.jar
 
       - name: Bump to next snapshot version
         run: |

--- a/.github/workflows/pit-report.yml
+++ b/.github/workflows/pit-report.yml
@@ -27,7 +27,7 @@ jobs:
         run: mvn -B install -DskipTests
 
       - name: Run mutation tests
-        run: mvn -B -pl fixedformat4j,fixedformat4j-processor pitest:mutationCoverage
+        run: mvn -B -pl fixedformat4j,fixedformat4j-processor,fixedformat4j-micrometer pitest:mutationCoverage
 
       - name: Publish PIT report to docs
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,9 +39,10 @@ mvn test -pl fixedformat4j -Dtest=TestBigDecimalFormatter#testSomeMethod
 
 ## Project Structure
 
-Three Maven modules:
+Four Maven modules:
 - `fixedformat4j/` — the core library (main artifact)
 - `fixedformat4j-processor/` — optional compile-time annotation processor (since 1.9.0); mirrors the statically decidable subset of the runtime validation via the mirror API. Any change to `FieldValidator`/`PatternValidator` checks must be mirrored in the processor's `FieldChecker`/`RecordValidator`, and vice versa.
+- `fixedformat4j-micrometer/` — optional Micrometer instrumentation (since 1.9.0); purely decorator-based (`FixedFormatMetrics` wraps `FixedFormatManager` and the reader strategy interfaces) — never add Micrometer dependencies or hooks to core.
 - `samples/` — usage examples
 
 Core production source is under `fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,10 @@ mvn test -pl fixedformat4j -Dtest=TestBigDecimalFormatter#testSomeMethod
 Four Maven modules:
 - `fixedformat4j/` — the core library (main artifact)
 - `fixedformat4j-processor/` — optional compile-time annotation processor (since 1.9.0); mirrors the statically decidable subset of the runtime validation via the mirror API. Any change to `FieldValidator`/`PatternValidator` checks must be mirrored in the processor's `FieldChecker`/`RecordValidator`, and vice versa.
-- `fixedformat4j-micrometer/` — optional Micrometer instrumentation (since 1.9.0); purely decorator-based (`FixedFormatMetrics` wraps `FixedFormatManager` and the reader strategy interfaces) — never add Micrometer dependencies or hooks to core.
+- `fixedformat4j-micrometer/` — optional Micrometer instrumentation module (since 1.9.0); decorator-based, no changes to the core artifact; never add Micrometer hooks to core.
 - `samples/` — usage examples
+
+**Version synchronisation:** none of the modules declare a `<parent>`. When bumping the project version, update the `<version>` element in **every** module pom.xml (`fixedformat4j/pom.xml`, `fixedformat4j-processor/pom.xml`, `fixedformat4j-micrometer/pom.xml`, `samples/pom.xml`) in addition to the root `pom.xml`.
 
 Core production source is under `fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/`.
 

--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Full documentation is available at **https://jeyben.github.io/fixedformat4j/**:
 - [Nested Records](https://jeyben.github.io/fixedformat4j/usage/nested-records) — embedding one record inside another
 - [Compile-time Validation](https://jeyben.github.io/fixedformat4j/usage/compile-time-validation) — optional `fixedformat4j-processor` artifact that turns `@Field`/`@Record` misconfigurations into `javac` errors
 - [Schema Introspection](https://jeyben.github.io/fixedformat4j/usage/introspection) — query the field layout of a `@Record` class at runtime via `FixedFormatIntrospector`
+- [Metrics](https://jeyben.github.io/fixedformat4j/usage/metrics) — optional `fixedformat4j-micrometer` artifact with load/export timers and parse-error counters for any Micrometer registry
 - [FAQ](https://jeyben.github.io/fixedformat4j/faq)
 - [Changelog](https://jeyben.github.io/fixedformat4j/changelog)
 

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -15,6 +15,8 @@
       url: /usage/compile-time-validation
     - title: Schema Introspection
       url: /usage/introspection
+    - title: Metrics
+      url: /usage/metrics
 - title: Examples
   url: /examples
 - title: Get It

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,22 @@ title: Changelog
 
 ### New features
 
+- **Micrometer instrumentation — new optional `fixedformat4j-micrometer` artifact**
+  ([#120](https://github.com/jeyben/fixedformat4j/issues/120)) —
+  decorator-based metrics for any Micrometer registry (Spring Boot Actuator, Quarkus,
+  Micronaut, plain Java). `FixedFormatMetrics.of(registry).instrument(manager)` publishes
+  `fixedformat.load` / `fixedformat.export` timers tagged by record class, a
+  `fixedformat.parse.errors` counter tagged by record class and field, and a
+  `fixedformat.metadata.cache.classes` gauge; wrapper factories (`countLines`,
+  `countUnmatched`, `countParseErrors`) plug into the existing `FixedFormatReaderBuilder`
+  strategy seams for `fixedformat.reader.lines.processed` / `.unmatched` / `.errors`. See
+  [Metrics](usage/metrics).
+
+  The core `fixedformat4j` artifact is unchanged and gains no dependencies. Performance:
+  instrumentation cost is a Micrometer registry lookup plus a timer sample per call
+  (nanosecond scale), only on instrumented managers/readers; applications without the module
+  are completely unaffected.
+
 - **Schema introspection API — `FixedFormatIntrospector`** ([#117](https://github.com/jeyben/fixedformat4j/issues/117)) —
   query the field layout of a `@Record` class at runtime. `FixedFormatManagerImpl` now also
   implements the new narrow `FixedFormatIntrospector` interface, whose `introspect(Class<?>)`

--- a/docs/get-it.md
+++ b/docs/get-it.md
@@ -75,6 +75,25 @@ annotationProcessor 'com.ancientprogramming.fixedformat4j:fixedformat4j-processo
 See [Compile-time validation](usage/compile-time-validation) for the full setup options and
 the list of checks.
 
+## Optional: Micrometer metrics
+
+Since 1.9.0 the `fixedformat4j-micrometer` artifact publishes load/export timers, parse-error
+counters, and reader line counters to any Micrometer registry:
+
+```xml
+<dependency>
+  <groupId>com.ancientprogramming.fixedformat4j</groupId>
+  <artifactId>fixedformat4j-micrometer</artifactId>
+  <version>1.9.0</version>
+</dependency>
+```
+
+```groovy
+implementation 'com.ancientprogramming.fixedformat4j:fixedformat4j-micrometer:1.9.0'
+```
+
+See [Metrics](usage/metrics) for wiring and the full meter list.
+
 ## Logging
 
 fixedformat4j uses [SLF4J](https://www.slf4j.org/) for logging. SLF4J is a logging facade — you must provide a binding on the classpath to route log output to your preferred logging framework (e.g. Logback, Log4j 2, or `slf4j-simple`).

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -96,3 +96,9 @@ Since 1.9.0 the optional `fixedformat4j-processor` artifact turns annotation mis
 (invalid date patterns, fields overflowing the record length, overlapping offsets, …) into
 `javac` errors instead of runtime exceptions. See [Compile-time validation](compile-time-validation).
 
+## Metrics
+
+Since 1.9.0 the optional `fixedformat4j-micrometer` artifact publishes load/export timers,
+parse-error counters, and reader line counters to any Micrometer registry — Spring Boot
+Actuator, Quarkus, Micronaut, or plain Java. See [Metrics](metrics).
+

--- a/docs/usage/metrics.md
+++ b/docs/usage/metrics.md
@@ -64,7 +64,7 @@ public FixedFormatManager fixedFormatManager(MeterRegistry registry) {
 | `fixedformat.reader.lines.processed` | counter | — | Lines read, including excluded and unmatched ones |
 | `fixedformat.reader.lines.unmatched` | counter | — | Lines matching no registered `LinePattern` |
 | `fixedformat.reader.lines.errors` | counter | — | Lines that matched but failed to parse |
-| `fixedformat.metadata.cache.classes` | gauge | — | Distinct `@Record` classes processed through the instrumented manager |
+| `fixedformat.metadata.cache.classes` | gauge | `manager.instance` | Distinct `@Record` classes processed through the instrumented manager |
 
 A spiking `fixedformat.parse.errors` rate is a leading indicator of upstream format drift —
 exactly the class of problem fixed-width integrations otherwise suffer silently.
@@ -72,7 +72,11 @@ exactly the class of problem fixed-width integrations otherwise suffer silently.
 **Gauge semantics:** the library's internal metadata cache is `ClassValue`-based and deliberately
 not enumerable (it must never pin classloaders in hot-reload environments), so the gauge counts
 the distinct record classes observed by the instrumented manager instance — the measurable
-equivalent of "classes currently cached" for the normal one-manager setup.
+equivalent of "classes currently cached" for the normal one-manager setup. The tracking set
+holds classes **weakly** for the same classloader-safety reason: record classes that become
+unreachable (e.g. after a hot-reload) drop out of the count. Each manager publishes its own
+gauge, disambiguated by the `manager.instance` tag, so several instrumented managers can share
+one registry.
 
 ## Performance
 

--- a/docs/usage/metrics.md
+++ b/docs/usage/metrics.md
@@ -69,6 +69,12 @@ public FixedFormatManager fixedFormatManager(MeterRegistry registry) {
 A spiking `fixedformat.parse.errors` rate is a leading indicator of upstream format drift —
 exactly the class of problem fixed-width integrations otherwise suffer silently.
 
+**Double-count with reader wiring:** when the reader's manager is instrumented (as in the wiring
+example above) *and* `countParseErrors` is used, a parse failure on a matched line increments
+both `fixedformat.reader.lines.errors` (coarse, line-level) **and** `fixedformat.parse.errors`
+(granular, tagged by `record.class` + `field`). This is by design — the two meters answer
+different questions — but operators should not sum them to count total failures.
+
 **Gauge semantics:** the library's internal metadata cache is `ClassValue`-based and deliberately
 not enumerable (it must never pin classloaders in hot-reload environments), so the gauge counts
 the distinct record classes observed by the instrumented manager instance — the measurable

--- a/docs/usage/metrics.md
+++ b/docs/usage/metrics.md
@@ -1,0 +1,81 @@
+---
+title: Metrics
+---
+
+# Metrics with Micrometer
+
+Since 1.9.0 the optional artifact `fixedformat4j-micrometer` instruments fixedformat4j with
+[Micrometer](https://micrometer.io/), the metrics facade used by Spring Boot Actuator, Quarkus,
+Micronaut, and plain Java applications. The core `fixedformat4j` artifact is unchanged and gains
+no dependencies — when the module is absent there is zero cost.
+
+## Add the dependency
+
+```xml
+<dependency>
+  <groupId>com.ancientprogramming.fixedformat4j</groupId>
+  <artifactId>fixedformat4j-micrometer</artifactId>
+  <version>1.9.0</version>
+</dependency>
+```
+
+```groovy
+implementation 'com.ancientprogramming.fixedformat4j:fixedformat4j-micrometer:1.9.0'
+```
+
+## Wiring
+
+All instrumentation is decorator-based via `FixedFormatMetrics`:
+
+```java
+MeterRegistry registry = ...;            // any Micrometer registry
+FixedFormatMetrics metrics = FixedFormatMetrics.of(registry);
+
+// instrument a manager — load/export timers, parse-error counter, class gauge
+FixedFormatManager manager = metrics.instrument(new FixedFormatManagerImpl());
+
+// instrument file processing — inject the manager and wrap the reader strategies
+FixedFormatReader reader = FixedFormatReader.builder()
+    .manager(manager)
+    .addMapping(CustomerRecord.class, LinePattern.prefix("C"))
+    .excludeLines(metrics.countLines(line -> false))   // counts every processed line
+    .unmatchStrategy(metrics.countUnmatched(UnmatchStrategy.skip()))
+    .parseErrorStrategy(metrics.countParseErrors(ParseErrorStrategy.skipAndLog()))
+    .build();
+```
+
+In Spring Boot, expose the instrumented manager as a bean — Actuator provides the
+`MeterRegistry`:
+
+```java
+@Bean
+public FixedFormatManager fixedFormatManager(MeterRegistry registry) {
+  return FixedFormatMetrics.of(registry).instrument(new FixedFormatManagerImpl());
+}
+```
+
+## Published meters
+
+| Metric | Type | Tags | Meaning |
+|---|---|---|---|
+| `fixedformat.load` | timer | `record.class` | Duration of each `load()` call |
+| `fixedformat.export` | timer | `record.class` | Duration of each `export()` call (both overloads) |
+| `fixedformat.parse.errors` | counter | `record.class`, `field` | `ParseException` occurrences (the exception still propagates) |
+| `fixedformat.reader.lines.processed` | counter | — | Lines read, including excluded and unmatched ones |
+| `fixedformat.reader.lines.unmatched` | counter | — | Lines matching no registered `LinePattern` |
+| `fixedformat.reader.lines.errors` | counter | — | Lines that matched but failed to parse |
+| `fixedformat.metadata.cache.classes` | gauge | — | Distinct `@Record` classes processed through the instrumented manager |
+
+A spiking `fixedformat.parse.errors` rate is a leading indicator of upstream format drift —
+exactly the class of problem fixed-width integrations otherwise suffer silently.
+
+**Gauge semantics:** the library's internal metadata cache is `ClassValue`-based and deliberately
+not enumerable (it must never pin classloaders in hot-reload environments), so the gauge counts
+the distinct record classes observed by the instrumented manager instance — the measurable
+equivalent of "classes currently cached" for the normal one-manager setup.
+
+## Performance
+
+Instrumentation cost is a Micrometer registry lookup plus a timer sample per call — nanosecond
+scale, and only on instrumented managers/readers. Uninstrumented code paths and applications
+without this module are completely unaffected.

--- a/fixedformat4j-micrometer/pom.xml
+++ b/fixedformat4j-micrometer/pom.xml
@@ -1,0 +1,195 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <name>Fixed Format for Java - Micrometer instrumentation</name>
+  <groupId>com.ancientprogramming.fixedformat4j</groupId>
+
+  <version>1.9.0-SNAPSHOT</version>
+  <artifactId>fixedformat4j-micrometer</artifactId>
+  <packaging>jar</packaging>
+
+  <inceptionYear>2008</inceptionYear>
+  <organization>
+    <name>Eyben Consult</name>
+    <url>https://eybenconsult.com</url>
+  </organization>
+  <description>
+    <![CDATA[Optional Micrometer instrumentation for fixedformat4j. Provides decorator-based timers,
+    counters and gauges for FixedFormatManager and FixedFormatReader without modifying or adding
+    dependencies to the core fixedformat4j artifact. Works with any MeterRegistry — Spring Boot
+    Actuator, Quarkus, Micronaut, or plain Java.]]>
+  </description>
+  <url>https://eybenconsult.com</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/jeyben/fixedformat4j/issues</url>
+  </issueManagement>
+
+  <scm>
+    <connection>scm:git:https://github.com/jeyben/fixedformat4j.git</connection>
+    <developerConnection>scm:git:git@github.com:jeyben/fixedformat4j.git</developerConnection>
+    <url>https://github.com/jeyben/fixedformat4j/tree/master/fixedformat4j-micrometer</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <developers>
+    <developer>
+      <name>Jacob von Eyben</name>
+      <id>jeyben</id>
+      <email>jacobvoneyben@gmail.com</email>
+      <organization/>
+      <organizationUrl/>
+      <url>https://eybenconsult.com</url>
+      <timezone>2</timezone>
+      <roles>
+        <role>Developer</role>
+      </roles>
+    </developer>
+  </developers>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.ancientprogramming.fixedformat4j</groupId>
+      <artifactId>fixedformat4j</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <version>1.17.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.13.4</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <defaultGoal>install</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.5</version>
+      </plugin>
+      <plugin>
+        <groupId>org.pitest</groupId>
+        <artifactId>pitest-maven</artifactId>
+        <version>1.23.1</version>
+        <configuration>
+          <targetClasses>
+            <param>com.ancientprogramming.fixedformat4j.micrometer.*</param>
+          </targetClasses>
+          <targetTests>
+            <param>com.ancientprogramming.fixedformat4j.micrometer.*</param>
+          </targetTests>
+          <outputFormats>
+            <outputFormat>HTML</outputFormat>
+            <outputFormat>XML</outputFormat>
+          </outputFormats>
+          <mutators>
+            <mutator>ALL</mutator>
+          </mutators>
+          <timestampedReports>false</timestampedReports>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-junit5-plugin</artifactId>
+            <version>1.2.3</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.15.0</version>
+        <configuration>
+          <release>11</release>
+          <encoding>UTF-8</encoding>
+          <debug>true</debug>
+          <proc>none</proc>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.4.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.10.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.12.0</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals><goal>jar</goal></goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.2.8</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals><goal>sign</goal></goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/fixedformat4j-micrometer/pom.xml
+++ b/fixedformat4j-micrometer/pom.xml
@@ -61,6 +61,11 @@
     </developer>
   </developers>
 
+  <!-- NOTE: this module intentionally has no <parent>; all modules in this reactor follow the
+       same convention (see fixedformat4j/pom.xml and fixedformat4j-processor/pom.xml).
+       When the project version is bumped, this file's <version> and the fixedformat4j
+       dependency version below (via ${project.version}) must be updated manually. -->
+
   <dependencies>
     <dependency>
       <groupId>com.ancientprogramming.fixedformat4j</groupId>
@@ -68,10 +73,14 @@
       <version>${project.version}</version>
     </dependency>
 
+    <!-- Declare the minimum Micrometer version whose API this module uses; consumers whose
+         project manages a higher version (e.g. via the Spring Boot BOM) will use their own
+         version — no conflict. All used APIs (Gauge.builder, Timer.start/Sample,
+         registry.counter/timer) are available since Micrometer 1.0. -->
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
-      <version>1.17.0</version>
+      <version>1.12.0</version>
     </dependency>
 
     <dependency>

--- a/fixedformat4j-micrometer/src/main/java/com/ancientprogramming/fixedformat4j/micrometer/FixedFormatMetrics.java
+++ b/fixedformat4j-micrometer/src/main/java/com/ancientprogramming/fixedformat4j/micrometer/FixedFormatMetrics.java
@@ -16,9 +16,12 @@
 package com.ancientprogramming.fixedformat4j.micrometer;
 
 import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
+import com.ancientprogramming.fixedformat4j.io.read.ParseErrorStrategy;
+import com.ancientprogramming.fixedformat4j.io.read.UnmatchStrategy;
 import io.micrometer.core.instrument.MeterRegistry;
 
 import java.util.Objects;
+import java.util.function.Predicate;
 
 /**
  * Entry point for Micrometer instrumentation of fixedformat4j.
@@ -68,5 +71,55 @@ public final class FixedFormatMetrics {
   public FixedFormatManager instrument(FixedFormatManager delegate) {
     Objects.requireNonNull(delegate, "delegate must not be null");
     return new MeteredFixedFormatManager(delegate, registry);
+  }
+
+  /**
+   * Wraps an {@link UnmatchStrategy} so every unmatched line increments
+   * {@code fixedformat.reader.lines.unmatched} before the wrapped strategy runs.
+   * Pass the result to {@code FixedFormatReaderBuilder.unmatchStrategy(...)}.
+   *
+   * @param delegate the strategy to wrap; must not be {@code null}
+   * @return a counting strategy with identical behavior; never {@code null}
+   */
+  public UnmatchStrategy countUnmatched(UnmatchStrategy delegate) {
+    Objects.requireNonNull(delegate, "delegate must not be null");
+    return (lineNumber, line) -> {
+      registry.counter("fixedformat.reader.lines.unmatched").increment();
+      delegate.handle(lineNumber, line);
+    };
+  }
+
+  /**
+   * Wraps a {@link ParseErrorStrategy} so every failed line increments
+   * {@code fixedformat.reader.lines.errors} before the wrapped strategy runs.
+   * Pass the result to {@code FixedFormatReaderBuilder.parseErrorStrategy(...)}.
+   *
+   * @param delegate the strategy to wrap; must not be {@code null}
+   * @return a counting strategy with identical behavior; never {@code null}
+   */
+  public ParseErrorStrategy countParseErrors(ParseErrorStrategy delegate) {
+    Objects.requireNonNull(delegate, "delegate must not be null");
+    return (wrapped, line, lineNumber) -> {
+      registry.counter("fixedformat.reader.lines.errors").increment();
+      delegate.handle(wrapped, line, lineNumber);
+    };
+  }
+
+  /**
+   * Wraps an exclude-lines predicate so every line read increments
+   * {@code fixedformat.reader.lines.processed} — the predicate is the first thing the reader
+   * evaluates for each line, which makes it the per-line seam. Pass the result to
+   * {@code FixedFormatReaderBuilder.excludeLines(...)}; when no lines should be excluded, pass
+   * {@code line -> false} as the delegate.
+   *
+   * @param excludeDelegate the exclusion predicate to wrap; must not be {@code null}
+   * @return a counting predicate with identical behavior; never {@code null}
+   */
+  public Predicate<String> countLines(Predicate<String> excludeDelegate) {
+    Objects.requireNonNull(excludeDelegate, "excludeDelegate must not be null");
+    return line -> {
+      registry.counter("fixedformat.reader.lines.processed").increment();
+      return excludeDelegate.test(line);
+    };
   }
 }

--- a/fixedformat4j-micrometer/src/main/java/com/ancientprogramming/fixedformat4j/micrometer/FixedFormatMetrics.java
+++ b/fixedformat4j-micrometer/src/main/java/com/ancientprogramming/fixedformat4j/micrometer/FixedFormatMetrics.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2004 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ancientprogramming.fixedformat4j.micrometer;
+
+import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
+import io.micrometer.core.instrument.MeterRegistry;
+
+import java.util.Objects;
+
+/**
+ * Entry point for Micrometer instrumentation of fixedformat4j.
+ *
+ * <p>All instrumentation is decorator-based: the core library is not modified and carries no
+ * Micrometer dependency. Wrap a {@link FixedFormatManager} via {@link #instrument} and, for
+ * file processing, pass the instrumented manager to
+ * {@code FixedFormatReader.builder().manager(...)} so reader-driven loads are timed too.
+ *
+ * <p>Instrumentation cost: meters are resolved through Micrometer's registry lookup per call
+ * (nanosecond-scale); uninstrumented managers and readers are completely unaffected.
+ *
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
+ * @since 1.9.0
+ */
+public final class FixedFormatMetrics {
+
+  private final MeterRegistry registry;
+
+  private FixedFormatMetrics(MeterRegistry registry) {
+    this.registry = registry;
+  }
+
+  /**
+   * Creates an instrumentation factory publishing to the given registry.
+   *
+   * @param registry the Micrometer registry to publish meters to; must not be {@code null}
+   * @return a new {@code FixedFormatMetrics}; never {@code null}
+   */
+  public static FixedFormatMetrics of(MeterRegistry registry) {
+    Objects.requireNonNull(registry, "registry must not be null");
+    return new FixedFormatMetrics(registry);
+  }
+
+  /**
+   * Wraps {@code delegate} so every {@code load()} and {@code export()} call is timed.
+   *
+   * <p>Published meters:
+   * <ul>
+   *   <li>{@code fixedformat.load} timer, tag {@code record.class}</li>
+   *   <li>{@code fixedformat.export} timer, tag {@code record.class}</li>
+   * </ul>
+   *
+   * @param delegate the manager to instrument; must not be {@code null}
+   * @return a {@link FixedFormatManager} with identical behavior that publishes meters; never {@code null}
+   */
+  public FixedFormatManager instrument(FixedFormatManager delegate) {
+    Objects.requireNonNull(delegate, "delegate must not be null");
+    return new MeteredFixedFormatManager(delegate, registry);
+  }
+}

--- a/fixedformat4j-micrometer/src/main/java/com/ancientprogramming/fixedformat4j/micrometer/FixedFormatMetrics.java
+++ b/fixedformat4j-micrometer/src/main/java/com/ancientprogramming/fixedformat4j/micrometer/FixedFormatMetrics.java
@@ -63,7 +63,16 @@ public final class FixedFormatMetrics {
    * <ul>
    *   <li>{@code fixedformat.load} timer, tag {@code record.class}</li>
    *   <li>{@code fixedformat.export} timer, tag {@code record.class}</li>
+   *   <li>{@code fixedformat.parse.errors} counter, tags {@code record.class} + {@code field}
+   *       (exception still propagates after counting)</li>
+   *   <li>{@code fixedformat.metadata.cache.classes} gauge, tag {@code manager.instance}</li>
    * </ul>
+   *
+   * <p><b>Note:</b> the returned manager implements only {@link FixedFormatManager}. If the
+   * delegate also implements
+   * {@code com.ancientprogramming.fixedformat4j.format.FixedFormatIntrospector}, keep a
+   * reference to the original {@code delegate} when introspection is needed; casting the
+   * returned wrapper will throw {@link ClassCastException}.
    *
    * @param delegate the manager to instrument; must not be {@code null}
    * @return a {@link FixedFormatManager} with identical behavior that publishes meters; never {@code null}
@@ -93,6 +102,13 @@ public final class FixedFormatMetrics {
    * Wraps a {@link ParseErrorStrategy} so every failed line increments
    * {@code fixedformat.reader.lines.errors} before the wrapped strategy runs.
    * Pass the result to {@code FixedFormatReaderBuilder.parseErrorStrategy(...)}.
+   *
+   * <p><b>Double-count note:</b> when the reader's manager is also instrumented via
+   * {@link #instrument}, a parse failure will increment <em>both</em> this counter
+   * ({@code fixedformat.reader.lines.errors}) <em>and</em>
+   * {@code fixedformat.parse.errors} (with {@code record.class} + {@code field} tags).
+   * This is intentional: the two meters serve different purposes — coarse line-level
+   * counting vs. granular field-level diagnosis.
    *
    * @param delegate the strategy to wrap; must not be {@code null}
    * @return a counting strategy with identical behavior; never {@code null}

--- a/fixedformat4j-micrometer/src/main/java/com/ancientprogramming/fixedformat4j/micrometer/MeteredFixedFormatManager.java
+++ b/fixedformat4j-micrometer/src/main/java/com/ancientprogramming/fixedformat4j/micrometer/MeteredFixedFormatManager.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2004 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ancientprogramming.fixedformat4j.micrometer;
+
+import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+/**
+ * Decorator that times {@link #load} and {@link #export} per record class. Behavior is
+ * delegated unchanged — including exceptions.
+ *
+ * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
+ * @since 1.9.0
+ */
+final class MeteredFixedFormatManager implements FixedFormatManager {
+
+  private static final String RECORD_CLASS_TAG = "record.class";
+
+  private final FixedFormatManager delegate;
+  private final MeterRegistry registry;
+
+  MeteredFixedFormatManager(FixedFormatManager delegate, MeterRegistry registry) {
+    this.delegate = delegate;
+    this.registry = registry;
+  }
+
+  @Override
+  public <T> T load(Class<T> clazz, String data) {
+    Timer.Sample sample = Timer.start(registry);
+    try {
+      return delegate.load(clazz, data);
+    } finally {
+      sample.stop(registry.timer("fixedformat.load", RECORD_CLASS_TAG, clazz.getName()));
+    }
+  }
+
+  @Override
+  public <T> String export(T instance) {
+    Timer.Sample sample = Timer.start(registry);
+    try {
+      return delegate.export(instance);
+    } finally {
+      sample.stop(registry.timer("fixedformat.export", RECORD_CLASS_TAG, instance.getClass().getName()));
+    }
+  }
+
+  @Override
+  public <T> String export(String template, T instance) {
+    Timer.Sample sample = Timer.start(registry);
+    try {
+      return delegate.export(template, instance);
+    } finally {
+      sample.stop(registry.timer("fixedformat.export", RECORD_CLASS_TAG, instance.getClass().getName()));
+    }
+  }
+}

--- a/fixedformat4j-micrometer/src/main/java/com/ancientprogramming/fixedformat4j/micrometer/MeteredFixedFormatManager.java
+++ b/fixedformat4j-micrometer/src/main/java/com/ancientprogramming/fixedformat4j/micrometer/MeteredFixedFormatManager.java
@@ -21,8 +21,10 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 
+import java.util.Collections;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.WeakHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Decorator that times {@link #load} and {@link #export} per record class, counts
@@ -32,7 +34,12 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * <p>The gauge counts classes observed by <em>this</em> instrumented manager: the global
  * {@code ClassValue}-based metadata cache is deliberately not enumerable (classloader-leak
- * safety), so per-manager observation is the measurable equivalent.
+ * safety), so per-manager observation is the measurable equivalent. The tracking set holds
+ * the classes <em>weakly</em> for the same reason — a long-lived manager must never pin a
+ * record class's defining classloader, so classes that become unreachable (e.g. after a
+ * hot-reload) drop out of the gauge. Each manager tags its gauge with a unique
+ * {@code manager.instance} value; Micrometer dedupes meters by name+tags, so an untagged
+ * gauge would be silently dropped for every manager but the first on a shared registry.
  *
  * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.9.0
@@ -40,16 +47,19 @@ import java.util.concurrent.ConcurrentHashMap;
 final class MeteredFixedFormatManager implements FixedFormatManager {
 
   private static final String RECORD_CLASS_TAG = "record.class";
+  private static final AtomicInteger INSTANCE_COUNTER = new AtomicInteger();
 
   private final FixedFormatManager delegate;
   private final MeterRegistry registry;
-  private final Set<Class<?>> seenClasses = ConcurrentHashMap.newKeySet();
+  private final Set<Class<?>> seenClasses =
+      Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
 
   MeteredFixedFormatManager(FixedFormatManager delegate, MeterRegistry registry) {
     this.delegate = delegate;
     this.registry = registry;
     Gauge.builder("fixedformat.metadata.cache.classes", seenClasses, Set::size)
         .description("Distinct @Record classes processed through this instrumented manager")
+        .tag("manager.instance", String.valueOf(INSTANCE_COUNTER.incrementAndGet()))
         .register(registry);
   }
 

--- a/fixedformat4j-micrometer/src/main/java/com/ancientprogramming/fixedformat4j/micrometer/MeteredFixedFormatManager.java
+++ b/fixedformat4j-micrometer/src/main/java/com/ancientprogramming/fixedformat4j/micrometer/MeteredFixedFormatManager.java
@@ -16,12 +16,23 @@
 package com.ancientprogramming.fixedformat4j.micrometer;
 
 import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
+import com.ancientprogramming.fixedformat4j.format.ParseException;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
- * Decorator that times {@link #load} and {@link #export} per record class. Behavior is
- * delegated unchanged — including exceptions.
+ * Decorator that times {@link #load} and {@link #export} per record class, counts
+ * {@link ParseException}s with record-class and field tags, and gauges the number of distinct
+ * record classes processed through this manager. Behavior is delegated unchanged — including
+ * exceptions, which are rethrown after counting.
+ *
+ * <p>The gauge counts classes observed by <em>this</em> instrumented manager: the global
+ * {@code ClassValue}-based metadata cache is deliberately not enumerable (classloader-leak
+ * safety), so per-manager observation is the measurable equivalent.
  *
  * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.9.0
@@ -32,17 +43,25 @@ final class MeteredFixedFormatManager implements FixedFormatManager {
 
   private final FixedFormatManager delegate;
   private final MeterRegistry registry;
+  private final Set<Class<?>> seenClasses = ConcurrentHashMap.newKeySet();
 
   MeteredFixedFormatManager(FixedFormatManager delegate, MeterRegistry registry) {
     this.delegate = delegate;
     this.registry = registry;
+    Gauge.builder("fixedformat.metadata.cache.classes", seenClasses, Set::size)
+        .description("Distinct @Record classes processed through this instrumented manager")
+        .register(registry);
   }
 
   @Override
   public <T> T load(Class<T> clazz, String data) {
+    seenClasses.add(clazz);
     Timer.Sample sample = Timer.start(registry);
     try {
       return delegate.load(clazz, data);
+    } catch (ParseException e) {
+      countParseError(e);
+      throw e;
     } finally {
       sample.stop(registry.timer("fixedformat.load", RECORD_CLASS_TAG, clazz.getName()));
     }
@@ -50,6 +69,7 @@ final class MeteredFixedFormatManager implements FixedFormatManager {
 
   @Override
   public <T> String export(T instance) {
+    seenClasses.add(instance.getClass());
     Timer.Sample sample = Timer.start(registry);
     try {
       return delegate.export(instance);
@@ -60,11 +80,19 @@ final class MeteredFixedFormatManager implements FixedFormatManager {
 
   @Override
   public <T> String export(String template, T instance) {
+    seenClasses.add(instance.getClass());
     Timer.Sample sample = Timer.start(registry);
     try {
       return delegate.export(template, instance);
     } finally {
       sample.stop(registry.timer("fixedformat.export", RECORD_CLASS_TAG, instance.getClass().getName()));
     }
+  }
+
+  private void countParseError(ParseException e) {
+    String recordClass = e.getAnnotatedClass() != null ? e.getAnnotatedClass().getName() : "unknown";
+    String field = e.getAnnotatedMethod() != null ? e.getAnnotatedMethod().getName() : "unknown";
+    registry.counter("fixedformat.parse.errors", RECORD_CLASS_TAG, recordClass, "field", field)
+        .increment();
   }
 }

--- a/fixedformat4j-micrometer/src/test/java/com/ancientprogramming/fixedformat4j/micrometer/BasicRecord.java
+++ b/fixedformat4j-micrometer/src/test/java/com/ancientprogramming/fixedformat4j/micrometer/BasicRecord.java
@@ -1,0 +1,33 @@
+package com.ancientprogramming.fixedformat4j.micrometer;
+
+import com.ancientprogramming.fixedformat4j.annotation.Align;
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.Record;
+
+/**
+ * Fixture record used by the instrumentation tests.
+ */
+@Record
+public class BasicRecord {
+
+  private String text;
+  private Integer amount;
+
+  @Field(offset = 1, length = 10)
+  public String getText() {
+    return text;
+  }
+
+  public void setText(String text) {
+    this.text = text;
+  }
+
+  @Field(offset = 11, length = 5, align = Align.RIGHT, paddingChar = '0')
+  public Integer getAmount() {
+    return amount;
+  }
+
+  public void setAmount(Integer amount) {
+    this.amount = amount;
+  }
+}

--- a/fixedformat4j-micrometer/src/test/java/com/ancientprogramming/fixedformat4j/micrometer/ChildFirstURLClassLoader.java
+++ b/fixedformat4j-micrometer/src/test/java/com/ancientprogramming/fixedformat4j/micrometer/ChildFirstURLClassLoader.java
@@ -1,0 +1,36 @@
+package com.ancientprogramming.fixedformat4j.micrometer;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * A classloader that skips parent delegation for a single nominated class, forcing the JVM to
+ * define it fresh from the URL array. Mirrors the helper used by the core module's
+ * classloader-leak tests.
+ */
+class ChildFirstURLClassLoader extends URLClassLoader {
+
+  private final String targetClassName;
+
+  ChildFirstURLClassLoader(URL[] urls, ClassLoader parent, String targetClassName) {
+    super(urls, parent);
+    this.targetClassName = targetClassName;
+  }
+
+  @Override
+  protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+    if (name.equals(targetClassName)) {
+      synchronized (getClassLoadingLock(name)) {
+        Class<?> c = findLoadedClass(name);
+        if (c == null) {
+          c = findClass(name);
+        }
+        if (resolve) {
+          resolveClass(c);
+        }
+        return c;
+      }
+    }
+    return super.loadClass(name, resolve);
+  }
+}

--- a/fixedformat4j-micrometer/src/test/java/com/ancientprogramming/fixedformat4j/micrometer/TestGaugeSafety.java
+++ b/fixedformat4j-micrometer/src/test/java/com/ancientprogramming/fixedformat4j/micrometer/TestGaugeSafety.java
@@ -1,0 +1,82 @@
+package com.ancientprogramming.fixedformat4j.micrometer;
+
+import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
+import com.ancientprogramming.fixedformat4j.format.impl.FixedFormatManagerImpl;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.lang.ref.WeakReference;
+import java.net.URL;
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Safety properties of the fixedformat.metadata.cache.classes gauge: the class-tracking set
+ * must not pin record classes (and thereby their classloaders — the exact leak the core
+ * ClassValue caches are designed to avoid), and each instrumented manager must keep its own
+ * working gauge even when several share one registry.
+ */
+class TestGaugeSafety {
+
+  private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+  @Test
+  void trackedRecordClassesDoNotPinTheirClassloader() throws Exception {
+    FixedFormatManager manager = FixedFormatMetrics.of(registry).instrument(new FixedFormatManagerImpl());
+
+    WeakReference<ClassLoader> loaderRef = loadThroughChildLoaderAndRelease(manager);
+
+    for (int i = 0; i < 20 && loaderRef.get() != null; i++) {
+      System.gc();
+      Thread.sleep(50);
+    }
+
+    assertNull(loaderRef.get(),
+        "the instrumented manager retained the child classloader after all strong references "
+            + "were released — the gauge's class-tracking set must hold record classes weakly, "
+            + "otherwise the long-lived manager pins every classloader it ever saw");
+  }
+
+  /**
+   * Extracted so the stack frame (and all its locals) is popped before the GC loop runs;
+   * only the long-lived manager survives — exactly the production topology.
+   */
+  @SuppressWarnings("unchecked")
+  private WeakReference<ClassLoader> loadThroughChildLoaderAndRelease(FixedFormatManager manager)
+      throws Exception {
+    URL testClassesUrl = BasicRecord.class.getProtectionDomain().getCodeSource().getLocation();
+    ChildFirstURLClassLoader loader = new ChildFirstURLClassLoader(
+        new URL[]{testClassesUrl},
+        FixedFormatManagerImpl.class.getClassLoader(),
+        BasicRecord.class.getName());
+
+    Class<Object> childRecordClass = (Class<Object>) loader.loadClass(BasicRecord.class.getName());
+    assertSame(loader, childRecordClass.getClassLoader());
+
+    manager.load(childRecordClass, "some text 00042");
+
+    return new WeakReference<>(loader);
+  }
+
+  @Test
+  void eachInstrumentedManagerOnASharedRegistryKeepsItsOwnGauge() {
+    FixedFormatMetrics metrics = FixedFormatMetrics.of(registry);
+    FixedFormatManager first = metrics.instrument(new FixedFormatManagerImpl());
+    FixedFormatManager second = metrics.instrument(new FixedFormatManagerImpl());
+
+    first.load(BasicRecord.class, "some text 00042");
+    second.load(TestMeteredManager.OtherRecord.class, "x");
+
+    Collection<Gauge> gauges = registry.find("fixedformat.metadata.cache.classes").gauges();
+    assertEquals(2, gauges.size(),
+        "each manager must register its own gauge; without a distinguishing tag Micrometer "
+            + "silently drops the second registration and never polls its class set");
+    for (Gauge gauge : gauges) {
+      assertEquals(1.0, gauge.value(), "each manager has seen exactly one distinct class");
+    }
+  }
+}

--- a/fixedformat4j-micrometer/src/test/java/com/ancientprogramming/fixedformat4j/micrometer/TestMeteredManager.java
+++ b/fixedformat4j-micrometer/src/test/java/com/ancientprogramming/fixedformat4j/micrometer/TestMeteredManager.java
@@ -1,0 +1,66 @@
+package com.ancientprogramming.fixedformat4j.micrometer;
+
+import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
+import com.ancientprogramming.fixedformat4j.format.impl.FixedFormatManagerImpl;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * The instrumented manager behaves exactly like its delegate while publishing
+ * fixedformat.load / fixedformat.export timers tagged with the record class.
+ */
+class TestMeteredManager {
+
+  private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+  private final FixedFormatManager manager =
+      FixedFormatMetrics.of(registry).instrument(new FixedFormatManagerImpl());
+
+  @Test
+  void loadIsTimedPerRecordClassAndReturnsTheDelegateResult() {
+    BasicRecord loaded = manager.load(BasicRecord.class, "some text 00042");
+
+    assertEquals("some text", loaded.getText());
+    assertEquals(42, loaded.getAmount());
+
+    Timer timer = registry.find("fixedformat.load")
+        .tag("record.class", BasicRecord.class.getName())
+        .timer();
+    assertNotNull(timer, "fixedformat.load timer must be registered with record.class tag");
+    assertEquals(1, timer.count());
+  }
+
+  @Test
+  void exportIsTimedPerRecordClassAndReturnsTheDelegateResult() {
+    BasicRecord record = new BasicRecord();
+    record.setText("some text");
+    record.setAmount(42);
+
+    String exported = manager.export(record);
+
+    assertEquals("some text 00042", exported);
+
+    Timer timer = registry.find("fixedformat.export")
+        .tag("record.class", BasicRecord.class.getName())
+        .timer();
+    assertNotNull(timer, "fixedformat.export timer must be registered with record.class tag");
+    assertEquals(1, timer.count());
+  }
+
+  @Test
+  void templateExportIsTimedThroughTheSameTimer() {
+    BasicRecord record = new BasicRecord();
+    record.setText("some text");
+    record.setAmount(42);
+
+    String exported = manager.export("xxxxxxxxxxxxxxx", record);
+
+    assertEquals("some text 00042", exported);
+    assertEquals(1, registry.find("fixedformat.export")
+        .tag("record.class", BasicRecord.class.getName())
+        .timer().count());
+  }
+}

--- a/fixedformat4j-micrometer/src/test/java/com/ancientprogramming/fixedformat4j/micrometer/TestMeteredManager.java
+++ b/fixedformat4j-micrometer/src/test/java/com/ancientprogramming/fixedformat4j/micrometer/TestMeteredManager.java
@@ -63,4 +63,53 @@ class TestMeteredManager {
         .tag("record.class", BasicRecord.class.getName())
         .timer().count());
   }
+
+  @Test
+  void parseFailuresAreCountedWithClassAndFieldTagsAndStillPropagate() {
+    org.junit.jupiter.api.Assertions.assertThrows(
+        com.ancientprogramming.fixedformat4j.format.ParseException.class,
+        () -> manager.load(BasicRecord.class, "some text xx,42"));
+
+    io.micrometer.core.instrument.Counter counter = registry.find("fixedformat.parse.errors")
+        .tag("record.class", BasicRecord.class.getName())
+        .tag("field", "getAmount")
+        .counter();
+    assertNotNull(counter, "fixedformat.parse.errors counter must carry record.class and field tags");
+    assertEquals(1.0, counter.count());
+  }
+
+  @Test
+  void gaugeReportsDistinctRecordClassesSeenThroughThisManager() {
+    manager.load(BasicRecord.class, "some text 00042");
+    manager.load(BasicRecord.class, "other text00001");
+
+    io.micrometer.core.instrument.Gauge gauge =
+        registry.find("fixedformat.metadata.cache.classes").gauge();
+    assertNotNull(gauge, "fixedformat.metadata.cache.classes gauge must be registered");
+    assertEquals(1.0, gauge.value(), "the same class loaded twice counts once");
+
+    BasicRecord record = new BasicRecord();
+    record.setText("t");
+    record.setAmount(1);
+    manager.export(record);
+    assertEquals(1.0, gauge.value(), "export of an already-seen class does not change the count");
+
+    manager.load(OtherRecord.class, "x");
+    assertEquals(2.0, gauge.value(), "a second distinct class increases the count");
+  }
+
+  @com.ancientprogramming.fixedformat4j.annotation.Record
+  public static class OtherRecord {
+
+    private String value;
+
+    @com.ancientprogramming.fixedformat4j.annotation.Field(offset = 1, length = 1)
+    public String getValue() {
+      return value;
+    }
+
+    public void setValue(String value) {
+      this.value = value;
+    }
+  }
 }

--- a/fixedformat4j-micrometer/src/test/java/com/ancientprogramming/fixedformat4j/micrometer/TestMeteredReaderStrategies.java
+++ b/fixedformat4j-micrometer/src/test/java/com/ancientprogramming/fixedformat4j/micrometer/TestMeteredReaderStrategies.java
@@ -1,0 +1,73 @@
+package com.ancientprogramming.fixedformat4j.micrometer;
+
+import com.ancientprogramming.fixedformat4j.format.impl.FixedFormatManagerImpl;
+import com.ancientprogramming.fixedformat4j.io.read.FixedFormatReader;
+import com.ancientprogramming.fixedformat4j.io.read.LinePattern;
+import com.ancientprogramming.fixedformat4j.io.read.ParseErrorStrategy;
+import com.ancientprogramming.fixedformat4j.io.read.ReadResult;
+import com.ancientprogramming.fixedformat4j.io.read.UnmatchStrategy;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * End-to-end instrumentation of FixedFormatReader through the existing core seams: the
+ * instrumented manager plus counting wrappers around the exclude predicate and the
+ * unmatch / parse-error strategies. No core changes — the wrappers delegate unchanged.
+ */
+class TestMeteredReaderStrategies {
+
+  private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+  private final FixedFormatMetrics metrics = FixedFormatMetrics.of(registry);
+
+  @Test
+  void readerLinesAreCountedAsProcessedUnmatchedAndErrored() {
+    FixedFormatReader reader = FixedFormatReader.builder()
+        .manager(metrics.instrument(new FixedFormatManagerImpl()))
+        .addMapping(BasicRecord.class, LinePattern.prefix("R"))
+        .excludeLines(metrics.countLines(line -> line.startsWith("#")))
+        .unmatchStrategy(metrics.countUnmatched(UnmatchStrategy.skip()))
+        .parseErrorStrategy(metrics.countParseErrors(ParseErrorStrategy.skipAndLog()))
+        .build();
+
+    String file = String.join("\n",
+        "# a comment line",          // excluded
+        "Rsome     00042",          // loads fine
+        "no pattern matches this",   // unmatched
+        "Rbad amount xxxxx");        // parse error
+
+    ReadResult result = reader.read(new StringReader(file));
+
+    assertEquals(1, result.get(BasicRecord.class).size());
+
+    assertEquals(4.0, registry.find("fixedformat.reader.lines.processed").counter().count(),
+        "every line, including excluded and unmatched ones, counts as processed");
+    assertEquals(1.0, registry.find("fixedformat.reader.lines.unmatched").counter().count());
+    assertEquals(1.0, registry.find("fixedformat.reader.lines.errors").counter().count());
+
+    assertEquals(2, registry.find("fixedformat.load")
+            .tag("record.class", BasicRecord.class.getName()).timer().count(),
+        "reader-driven loads (incl. the failed one) flow through the instrumented manager");
+  }
+
+  @Test
+  void wrappersDelegateToTheWrappedStrategies() {
+    StringBuilder unmatchedSeen = new StringBuilder();
+    StringBuilder errorsSeen = new StringBuilder();
+
+    FixedFormatReader reader = FixedFormatReader.builder()
+        .manager(metrics.instrument(new FixedFormatManagerImpl()))
+        .addMapping(BasicRecord.class, LinePattern.prefix("R"))
+        .unmatchStrategy(metrics.countUnmatched((lineNumber, line) -> unmatchedSeen.append(lineNumber)))
+        .parseErrorStrategy(metrics.countParseErrors((wrapped, line, lineNumber) -> errorsSeen.append(lineNumber)))
+        .build();
+
+    reader.read(new StringReader("unmatched\nRbad amount xxxxx"));
+
+    assertEquals("1", unmatchedSeen.toString(), "wrapped unmatch strategy still runs");
+    assertEquals("2", errorsSeen.toString(), "wrapped parse-error strategy still runs");
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
   <modules>
     <module>fixedformat4j</module>
     <module>fixedformat4j-processor</module>
+    <module>fixedformat4j-micrometer</module>
     <module>samples</module>
   </modules>
 


### PR DESCRIPTION
## Summary

Implements the **metrics scope** of issue #120: a new optional Maven artifact `fixedformat4j-micrometer` that instruments fixedformat4j via Micrometer — usable with Spring Boot Actuator, Quarkus, Micronaut, or plain Java. **The core `fixedformat4j` artifact is unchanged and gains no dependencies.**

Per maintainer decision, the Spring Actuator endpoint from the issue is deferred to a follow-up PR (it depends on #117's introspection API, see PR #138, and would add optional Spring deps).

## Design — decorator-based, zero core changes

`FixedFormatMetrics.of(registry)` is the single public entry point:

| Method | Meters |
|---|---|
| `instrument(FixedFormatManager)` | `fixedformat.load` / `fixedformat.export` timers (tag `record.class`); `fixedformat.parse.errors` counter (tags `record.class`, `field`; exception rethrown after counting); `fixedformat.metadata.cache.classes` gauge |
| `countUnmatched(UnmatchStrategy)` | `fixedformat.reader.lines.unmatched` |
| `countParseErrors(ParseErrorStrategy)` | `fixedformat.reader.lines.errors` |
| `countLines(Predicate<String>)` | `fixedformat.reader.lines.processed` |

The reader needed no hooks: `FixedFormatReaderBuilder.manager(...)` injects the instrumented manager (reader-driven loads are timed), the strategies are `@FunctionalInterface`s, and the `excludeLines` predicate is evaluated first for every line — the natural per-line counter seam.

**Gauge semantics (conscious trade-off):** the internal metadata cache is `ClassValue`-based and deliberately not enumerable (classloader-leak safety), so the gauge counts distinct record classes observed through the instrumented manager — the measurable equivalent for the issue's "currently cached" wording. Documented in Javadoc and the metrics guide.

## Compatibility

**Minor (1.9.0), non-breaking.** Framework-breaking checklist: **N/A — purely additive**: new optional module; only `MeteredFixedFormatManager` (package-private) implements existing interfaces, delegating behavior unchanged including exceptions. Zero cost for applications without the module.

## Tests

7 behavior tests on a `SimpleMeterRegistry` (no extra test deps): timers for load/export/template-export with identical delegate results, parse-error counter tags + propagation, gauge idempotence per class, and an end-to-end `FixedFormatReader` run (excluded + loaded + unmatched + malformed lines → 4 processed / 1 unmatched / 1 error / 2 timed loads) plus wrapped-strategy delegation. Full reactor green on JDK 11 and JDK 25.

## CI / release / docs

- `maven-publish.yml` deploys + release-uploads the new artifacts; `pit-report.yml` covers the module (CI-only).
- New `docs/usage/metrics.md` (wiring incl. Spring `@Bean`, meter table, gauge note, perf note), nav + usage index + `get-it.md` links, changelog `[Unreleased]` entry, README link, CLAUDE.md module note ("never add Micrometer hooks to core").

## Follow-up

- Spring Actuator `@Endpoint(id = "fixedformat")` exposing the record-class registry over HTTP — after this PR and #138 (#117) merge.

Closes #120 (metrics scope; endpoint tracked as follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)