### PR TITLE
perf: cache meters per record class in MeteredFixedFormatManager (#140)

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -86,4 +86,46 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <!-- Opt-in benchmark of the fixedformat4j-micrometer decorator overhead (issue #140).
+         Kept out of the default build: run.sh sweeps released target versions back to 1.6.1,
+         where the micrometer artifact does not exist. Activate manually:
+           mvn -f benchmarks/pom.xml clean package -P micrometer-bench \
+               -Dbenchmark.target.version=1.9.0-SNAPSHOT
+           java -jar benchmarks/target/benchmarks.jar Metered -->
+    <profile>
+      <id>micrometer-bench</id>
+      <dependencies>
+        <dependency>
+          <groupId>com.ancientprogramming.fixedformat4j</groupId>
+          <artifactId>fixedformat4j-micrometer</artifactId>
+          <version>${benchmark.target.version}</version>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <version>3.6.0</version>
+            <executions>
+              <execution>
+                <id>add-micrometer-bench-source</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>src/micrometer/java</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/benchmarks/src/micrometer/java/com/ancientprogramming/fixedformat4j/bench/MeteredManagerBenchmark.java
+++ b/benchmarks/src/micrometer/java/com/ancientprogramming/fixedformat4j/bench/MeteredManagerBenchmark.java
@@ -1,0 +1,72 @@
+package com.ancientprogramming.fixedformat4j.bench;
+
+import com.ancientprogramming.fixedformat4j.bench.fixtures.SmallRecord;
+import com.ancientprogramming.fixedformat4j.bench.fixtures.WideRecord;
+import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
+import com.ancientprogramming.fixedformat4j.format.impl.FixedFormatManagerImpl;
+import com.ancientprogramming.fixedformat4j.micrometer.FixedFormatMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Measures the per-call overhead of the fixedformat4j-micrometer decorator (issue #140):
+ * each load/export pair runs once against the bare manager and once against the instrumented
+ * one — the delta is the decorator cost. Compiled only under the {@code micrometer-bench}
+ * profile because the module does not exist in the older target versions run.sh sweeps.
+ */
+@BenchmarkMode({Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(value = 2, jvmArgs = {"-Xms1G", "-Xmx1G"})
+@State(Scope.Benchmark)
+public class MeteredManagerBenchmark {
+
+    private FixedFormatManager bare;
+    private FixedFormatManager instrumented;
+    private String smallData;
+    private String wideData;
+    private SmallRecord smallInstance;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        bare = new FixedFormatManagerImpl();
+        instrumented = FixedFormatMetrics.of(new SimpleMeterRegistry())
+            .instrument(new FixedFormatManagerImpl());
+        smallData = SmallRecord.SAMPLE_DATA;
+        wideData = WideRecord.SAMPLE_DATA;
+        smallInstance = SmallRecord.sampleInstance();
+    }
+
+    @Benchmark
+    public SmallRecord loadSmallBare() {
+        return bare.load(SmallRecord.class, smallData);
+    }
+
+    @Benchmark
+    public SmallRecord loadSmallInstrumented() {
+        return instrumented.load(SmallRecord.class, smallData);
+    }
+
+    @Benchmark
+    public WideRecord loadWideBare() {
+        return bare.load(WideRecord.class, wideData);
+    }
+
+    @Benchmark
+    public WideRecord loadWideInstrumented() {
+        return instrumented.load(WideRecord.class, wideData);
+    }
+
+    @Benchmark
+    public String exportSmallBare() {
+        return bare.export(smallInstance);
+    }
+
+    @Benchmark
+    public String exportSmallInstrumented() {
+        return instrumented.export(smallInstance);
+    }
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,10 +19,12 @@ title: Changelog
   strategy seams for `fixedformat.reader.lines.processed` / `.unmatched` / `.errors`. See
   [Metrics](usage/metrics).
 
-  The core `fixedformat4j` artifact is unchanged and gains no dependencies. Performance:
-  instrumentation cost is a Micrometer registry lookup plus a timer sample per call
-  (nanosecond scale), only on instrumented managers/readers; applications without the module
-  are completely unaffected.
+  The core `fixedformat4j` artifact is unchanged and gains no dependencies. Performance
+  ([#140](https://github.com/jeyben/fixedformat4j/issues/140)): timers are cached per record
+  class in a GC-safe `ClassValue` and reader counters are resolved once per wrapper, so the
+  steady-state cost is just the timer sample (two `System.nanoTime()` calls) per operation or
+  one counter increment per line — tens of nanoseconds, only on instrumented managers/readers;
+  applications without the module are completely unaffected.
 
 - **Schema introspection API — `FixedFormatIntrospector`** ([#117](https://github.com/jeyben/fixedformat4j/issues/117)) —
   query the field layout of a `@Record` class at runtime. `FixedFormatManagerImpl` now also

--- a/docs/usage/metrics.md
+++ b/docs/usage/metrics.md
@@ -86,6 +86,11 @@ one registry.
 
 ## Performance
 
-Instrumentation cost is a Micrometer registry lookup plus a timer sample per call — nanosecond
-scale, and only on instrumented managers/readers. Uninstrumented code paths and applications
-without this module are completely unaffected.
+Meters are resolved once, not per call: the instrumented manager caches its timers per record
+class (in a GC-safe `ClassValue`, so cached timers never pin a record class's classloader), and
+the reader wrappers resolve their counters when the wrapper is created. The steady-state cost
+per `load()`/`export()` is therefore just the timer sample — two `System.nanoTime()` calls —
+plus a set lookup for the gauge; per reader line it is a single counter increment. Measured with
+the JMH benchmark in the `benchmarks` module (`-P micrometer-bench`), the instrumented manager
+adds on the order of tens of nanoseconds per operation. Uninstrumented code paths and
+applications without this module are completely unaffected.

--- a/fixedformat4j-micrometer/src/main/java/com/ancientprogramming/fixedformat4j/micrometer/FixedFormatMetrics.java
+++ b/fixedformat4j-micrometer/src/main/java/com/ancientprogramming/fixedformat4j/micrometer/FixedFormatMetrics.java
@@ -18,6 +18,7 @@ package com.ancientprogramming.fixedformat4j.micrometer;
 import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
 import com.ancientprogramming.fixedformat4j.io.read.ParseErrorStrategy;
 import com.ancientprogramming.fixedformat4j.io.read.UnmatchStrategy;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 
 import java.util.Objects;
@@ -31,8 +32,10 @@ import java.util.function.Predicate;
  * file processing, pass the instrumented manager to
  * {@code FixedFormatReader.builder().manager(...)} so reader-driven loads are timed too.
  *
- * <p>Instrumentation cost: meters are resolved through Micrometer's registry lookup per call
- * (nanosecond-scale); uninstrumented managers and readers are completely unaffected.
+ * <p>Instrumentation cost: timers are resolved once per record class ({@code ClassValue}
+ * cache inside the instrumented manager) and reader counters once per wrapper, so the
+ * steady-state hot path adds only the timer sample (two {@code System.nanoTime()} calls) or a
+ * counter increment. Uninstrumented managers and readers are completely unaffected.
  *
  * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.9.0
@@ -92,8 +95,9 @@ public final class FixedFormatMetrics {
    */
   public UnmatchStrategy countUnmatched(UnmatchStrategy delegate) {
     Objects.requireNonNull(delegate, "delegate must not be null");
+    Counter unmatched = registry.counter("fixedformat.reader.lines.unmatched");
     return (lineNumber, line) -> {
-      registry.counter("fixedformat.reader.lines.unmatched").increment();
+      unmatched.increment();
       delegate.handle(lineNumber, line);
     };
   }
@@ -115,8 +119,9 @@ public final class FixedFormatMetrics {
    */
   public ParseErrorStrategy countParseErrors(ParseErrorStrategy delegate) {
     Objects.requireNonNull(delegate, "delegate must not be null");
+    Counter errors = registry.counter("fixedformat.reader.lines.errors");
     return (wrapped, line, lineNumber) -> {
-      registry.counter("fixedformat.reader.lines.errors").increment();
+      errors.increment();
       delegate.handle(wrapped, line, lineNumber);
     };
   }
@@ -133,8 +138,9 @@ public final class FixedFormatMetrics {
    */
   public Predicate<String> countLines(Predicate<String> excludeDelegate) {
     Objects.requireNonNull(excludeDelegate, "excludeDelegate must not be null");
+    Counter processed = registry.counter("fixedformat.reader.lines.processed");
     return line -> {
-      registry.counter("fixedformat.reader.lines.processed").increment();
+      processed.increment();
       return excludeDelegate.test(line);
     };
   }

--- a/fixedformat4j-micrometer/src/main/java/com/ancientprogramming/fixedformat4j/micrometer/MeteredFixedFormatManager.java
+++ b/fixedformat4j-micrometer/src/main/java/com/ancientprogramming/fixedformat4j/micrometer/MeteredFixedFormatManager.java
@@ -41,6 +41,12 @@ import java.util.concurrent.atomic.AtomicInteger;
  * {@code manager.instance} value; Micrometer dedupes meters by name+tags, so an untagged
  * gauge would be silently dropped for every manager but the first on a shared registry.
  *
+ * <p>Timers are resolved once per record class through {@link ClassValue} caches — never
+ * through a {@code Map<Class, Timer>}, which would strongly pin record classes and reintroduce
+ * the classloader leak described above. The registry-side meter retains only the class
+ * <em>name</em> string, which pins nothing. Since Micrometer dedupes by name+tags, two managers
+ * on one registry still share the same underlying timer per record class.
+ *
  * @author Jacob von Eyben - <a href="https://eybenconsult.com">https://eybenconsult.com</a>
  * @since 1.9.0
  */
@@ -54,6 +60,20 @@ final class MeteredFixedFormatManager implements FixedFormatManager {
   private final Set<Class<?>> seenClasses =
       Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
 
+  private final ClassValue<Timer> loadTimers = new ClassValue<>() {
+    @Override
+    protected Timer computeValue(Class<?> clazz) {
+      return registry.timer("fixedformat.load", RECORD_CLASS_TAG, clazz.getName());
+    }
+  };
+
+  private final ClassValue<Timer> exportTimers = new ClassValue<>() {
+    @Override
+    protected Timer computeValue(Class<?> clazz) {
+      return registry.timer("fixedformat.export", RECORD_CLASS_TAG, clazz.getName());
+    }
+  };
+
   MeteredFixedFormatManager(FixedFormatManager delegate, MeterRegistry registry) {
     this.delegate = delegate;
     this.registry = registry;
@@ -65,6 +85,7 @@ final class MeteredFixedFormatManager implements FixedFormatManager {
 
   @Override
   public <T> T load(Class<T> clazz, String data) {
+    Timer timer = loadTimers.get(clazz);
     seenClasses.add(clazz);
     Timer.Sample sample = Timer.start(registry);
     try {
@@ -73,29 +94,31 @@ final class MeteredFixedFormatManager implements FixedFormatManager {
       countParseError(e);
       throw e;
     } finally {
-      sample.stop(registry.timer("fixedformat.load", RECORD_CLASS_TAG, clazz.getName()));
+      sample.stop(timer);
     }
   }
 
   @Override
   public <T> String export(T instance) {
+    Timer timer = exportTimers.get(instance.getClass());
     seenClasses.add(instance.getClass());
     Timer.Sample sample = Timer.start(registry);
     try {
       return delegate.export(instance);
     } finally {
-      sample.stop(registry.timer("fixedformat.export", RECORD_CLASS_TAG, instance.getClass().getName()));
+      sample.stop(timer);
     }
   }
 
   @Override
   public <T> String export(String template, T instance) {
+    Timer timer = exportTimers.get(instance.getClass());
     seenClasses.add(instance.getClass());
     Timer.Sample sample = Timer.start(registry);
     try {
       return delegate.export(template, instance);
     } finally {
-      sample.stop(registry.timer("fixedformat.export", RECORD_CLASS_TAG, instance.getClass().getName()));
+      sample.stop(timer);
     }
   }
 


### PR DESCRIPTION
## Summary

Implements issue #140: removes the per-call Micrometer registry lookup from the instrumentation hot path. Metric names, tags, and values are byte-identical — this is a pure internal optimization of the (still unreleased) `fixedformat4j-micrometer` module, so no consumer ever sees the slower version.

## Changes

- **`MeteredFixedFormatManager`**: `fixedformat.load`/`fixedformat.export` timers are now resolved once per record class via two `ClassValue<Timer>` caches. Deliberately **not** a `Map<Class, Timer>` — that would strongly pin record classes and reintroduce the classloader leak fixed in the PR #139 review. The existing `TestGaugeSafety` leak test (child-first classloader + GC-await) now exercises the timer cache too and acts as the permanent regression guard. Registry-side dedup by name+tags means multiple managers on one registry still share the same timer per class — semantics unchanged. The parse-error counter stays uncached (exceptional path, exception-derived tags).
- **`FixedFormatMetrics`**: the three reader wrappers (`countLines`/`countUnmatched`/`countParseErrors`) resolve their untagged `Counter` once at wrapper construction and capture it in the lambda.
- **New opt-in `micrometer-bench` profile** in the benchmarks module (`benchmarks/src/micrometer/java`, bare-vs-instrumented load/export pairs). Manual activation only: `run.sh` sweeps released target versions back to 1.6.1 where the micrometer artifact doesn't exist — the default build is untouched (verified).

## Measured (JMH, AverageTime, JDK 11 / Temurin, macOS, `-f 1 -wi 3 -i 5` — indicative)

| operation | decorator overhead before | after |
|---|---|---|
| `load` small record (5 fields, ~0.53 µs bare) | +102 ns (~19%) | **+52 ns (~10%)** |
| `export` small record (~0.68 µs bare) | +115 ns (~17%) | **+68 ns (~10%)** |
| `load` wide record (~0.75 µs bare) | +34 ns | within run-to-run noise |

The residual ~50–70 ns is the irreducible timer sample (two `System.nanoTime()` calls) plus the gauge's weak-set lookup, exactly as predicted in the issue. Raw JMH JSON available; reproduce with:

```
mvn install -DskipTests
mvn -f benchmarks/pom.xml clean package -P micrometer-bench -Dbenchmark.target.version=1.9.0-SNAPSHOT
java -jar benchmarks/target/benchmarks.jar Metered
```

## Compatibility

**Non-breaking, patch-grade** — contained in the optional module, observable metric output identical, framework-breaking checklist N/A. All 9 module tests pass unchanged (zero test modifications); full reactor green on JDK 11 and JDK 25.

## Docs

`docs/usage/metrics.md` Performance section and the changelog `[Unreleased]` #120 entry updated to the measured characteristics (module unreleased, so the perf note is folded into the existing entry rather than a separate one).

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)