### PR TITLE
ci: publish PIT mutation report via PR instead of direct push to master

### DIFF
--- a/.github/workflows/pit-report.yml
+++ b/.github/workflows/pit-report.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
   actions: write
 
 jobs:
@@ -29,7 +30,11 @@ jobs:
       - name: Run mutation tests
         run: mvn -B -pl fixedformat4j,fixedformat4j-processor,fixedformat4j-micrometer pitest:mutationCoverage
 
-      - name: Publish PIT report to docs
+      # master is protected (required status check "build"), so the report
+      # cannot be pushed directly — it goes through a PR instead (#142).
+      - name: Open PR with updated PIT report
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           STATS=$(awk '/<tbody>/,/<\/tbody>/' fixedformat4j/target/pit-reports/index.html | grep -o '[0-9]*%')
           LINE_COV=$(echo "$STATS" | sed -n '1p')
@@ -41,10 +46,19 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add docs/pit-reports/ docs/mutation-score.json
-          git diff --staged --quiet || git commit -m "chore: update PIT mutation report"
-          git push
-
-      - name: Trigger pages deployment
-        run: gh workflow run pages.yml --ref master
-        env:
-          GH_TOKEN: ${{ github.token }}
+          if git diff --staged --quiet; then
+            echo "PIT report unchanged; nothing to publish."
+            exit 0
+          fi
+          BRANCH="chore/pit-report-${{ github.run_id }}"
+          git checkout -b "$BRANCH"
+          git commit -m "chore: update PIT mutation report"
+          git push origin "$BRANCH"
+          gh pr create \
+            --base master \
+            --head "$BRANCH" \
+            --title "chore: update PIT mutation report" \
+            --body "$(printf 'Automated PIT mutation report from run %s.\n\nLine coverage: %s | Mutation coverage: %s | Test strength: %s\n\nMerging this PR updates docs/pit-reports/ and docs/mutation-score.json; the pages deployment is triggered by the merge (pages.yml watches docs/** on master).' "${{ github.run_id }}" "$LINE_COV" "$MUT_COV" "$TEST_STR")"
+          # Pushes made with GITHUB_TOKEN do not trigger other workflows, so
+          # the required "build" check must be dispatched explicitly.
+          gh workflow run nightly-build.yml --ref "$BRANCH"


### PR DESCRIPTION
Fixes #142

## Problem

The `PIT Mutation Report` workflow committed the generated report and ran `git push` directly to `master`. Branch protection on `master` requires the `build` status check, so the push was rejected (`push declined due to repository rule violations`) and the report never reached the docs site. Failing run: https://github.com/jeyben/fixedformat4j/actions/runs/27411980154

## Change

`pit-report.yml` now publishes the mutation results through a pull request:

- The updated `docs/pit-reports/` and `docs/mutation-score.json` are committed to a `chore/pit-report-<run-id>` branch and a PR against `master` is opened via `gh pr create` (the PR body carries the line/mutation/test-strength scores).
- Pushes made with `GITHUB_TOKEN` do not trigger other workflows, so the required `build` check would never run on the PR. The workflow therefore dispatches `nightly-build.yml` on the report branch explicitly (`gh workflow run`), which attaches the `build` check run to the PR's head SHA and makes the PR mergeable.
- If the regenerated report is identical, the step exits early and no PR is created.
- The explicit `pages.yml` trigger step is removed: `pages.yml` already deploys on pushes to `master` touching `docs/**`, which a user-performed merge of the report PR produces.
- Added `pull-requests: write` to the workflow permissions (needed for `gh pr create`); `actions: write` is retained for the `gh workflow run` dispatch.

## Notes

- Repo-level auto-merge is disabled, so the report PR is merged manually once `build` is green. Merging via the UI uses the user's credentials, so the pages deployment triggers normally.
- "Allow GitHub Actions to create and approve pull requests" is enabled on the repo, so `gh pr create` with the default token works.
- No library code or behavior changes — CI only, so no changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
