### PR TITLE
Prepare 2.0.0-SNAPSHOT development

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ For every annotation attribute, type, and advanced option see the [Annotations r
 
 FixedFormat4J's annotation-only approach means no external schema files to version, no XML to keep in sync with your Java classes, and no framework-specific integration layer to pull in.
 
-## Latest release — 1.8.1 (2026-05-05)
+## Latest release — 1.9.0 (2026-06-12)
 
 See the [Changelog](https://jeyben.github.io/fixedformat4j/changelog) for what's new.
 
@@ -98,20 +98,20 @@ FixedFormat4J is published to **Maven Central**. No repository configuration or 
 <dependency>
   <groupId>com.ancientprogramming.fixedformat4j</groupId>
   <artifactId>fixedformat4j</artifactId>
-  <version>1.8.1</version>
+  <version>1.9.0</version>
 </dependency>
 ```
 
 **Gradle (Groovy DSL)**
 
 ```groovy
-implementation 'com.ancientprogramming.fixedformat4j:fixedformat4j:1.8.1'
+implementation 'com.ancientprogramming.fixedformat4j:fixedformat4j:1.9.0'
 ```
 
 **Gradle (Kotlin DSL)**
 
 ```kotlin
-implementation("com.ancientprogramming.fixedformat4j:fixedformat4j:1.8.1")
+implementation("com.ancientprogramming.fixedformat4j:fixedformat4j:1.9.0")
 ```
 
 **Ivy**
@@ -119,7 +119,7 @@ implementation("com.ancientprogramming.fixedformat4j:fixedformat4j:1.8.1")
 ```xml
 <dependency org="com.ancientprogramming.fixedformat4j"
             name="fixedformat4j"
-            rev="1.8.1"/>
+            rev="1.9.0"/>
 ```
 
 Requires **Java 11 or later**. If you want log output, add an [SLF4J binding](https://www.slf4j.org/manual.html#swapping) such as `logback-classic`; without one the library still works, just silently.

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.ancientprogramming.fixedformat4j</groupId>
   <artifactId>fixedformat4j-benchmarks</artifactId>
-  <version>1.9.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Fixed Format for Java - Benchmarks</name>
 
@@ -92,7 +92,7 @@
          Kept out of the default build: run.sh sweeps released target versions back to 1.6.1,
          where the micrometer artifact does not exist. Activate manually:
            mvn -f benchmarks/pom.xml clean package -P micrometer-bench \
-               -Dbenchmark.target.version=1.9.0-SNAPSHOT
+               -Dbenchmark.target.version=2.0.0-SNAPSHOT
            java -jar benchmarks/target/benchmarks.jar Metered -->
     <profile>
       <id>micrometer-bench</id>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@ title: Changelog
 
 # Changelog
 
-## [Unreleased] 1.9.0
+## 1.9.0 (2026-06-12)
 
 ### New features
 

--- a/docs/get-it.md
+++ b/docs/get-it.md
@@ -4,7 +4,7 @@ title: Get fixedformat4j
 
 # Get the latest version of fixedformat4j
 
-fixedformat4j 1.8.0 is published to **Maven Central**.
+fixedformat4j 1.9.0 is published to **Maven Central**.
 
 ## Requirements
 
@@ -24,7 +24,7 @@ Add to your `pom.xml`:
 <dependency>
   <groupId>com.ancientprogramming.fixedformat4j</groupId>
   <artifactId>fixedformat4j</artifactId>
-  <version>1.8.0</version>
+  <version>1.9.0</version>
 </dependency>
 ```
 
@@ -33,13 +33,13 @@ Add to your `pom.xml`:
 Groovy DSL (`build.gradle`):
 
 ```groovy
-implementation 'com.ancientprogramming.fixedformat4j:fixedformat4j:1.8.0'
+implementation 'com.ancientprogramming.fixedformat4j:fixedformat4j:1.9.0'
 ```
 
 Kotlin DSL (`build.gradle.kts`):
 
 ```kotlin
-implementation("com.ancientprogramming.fixedformat4j:fixedformat4j:1.8.0")
+implementation("com.ancientprogramming.fixedformat4j:fixedformat4j:1.9.0")
 ```
 
 ### Ivy
@@ -49,7 +49,7 @@ Add to your `ivy.xml` dependencies block:
 ```xml
 <dependency org="com.ancientprogramming.fixedformat4j"
             name="fixedformat4j"
-            rev="1.8.0"/>
+            rev="1.9.0"/>
 ```
 
 ## Optional: compile-time validation

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -21,7 +21,7 @@ The latest version is always available on [Maven Central](https://search.maven.o
 <dependency>
   <groupId>com.ancientprogramming.fixedformat4j</groupId>
   <artifactId>fixedformat4j</artifactId>
-  <version>1.8.0</version>
+  <version>1.9.0</version>
 </dependency>
 ```
 
@@ -30,13 +30,13 @@ The latest version is always available on [Maven Central](https://search.maven.o
 Groovy DSL (`build.gradle`):
 
 ```groovy
-implementation 'com.ancientprogramming.fixedformat4j:fixedformat4j:1.8.0'
+implementation 'com.ancientprogramming.fixedformat4j:fixedformat4j:1.9.0'
 ```
 
 Kotlin DSL (`build.gradle.kts`):
 
 ```kotlin
-implementation("com.ancientprogramming.fixedformat4j:fixedformat4j:1.8.0")
+implementation("com.ancientprogramming.fixedformat4j:fixedformat4j:1.9.0")
 ```
 
 #### Ivy
@@ -44,7 +44,7 @@ implementation("com.ancientprogramming.fixedformat4j:fixedformat4j:1.8.0")
 ```xml
 <dependency org="com.ancientprogramming.fixedformat4j"
             name="fixedformat4j"
-            rev="1.8.0"/>
+            rev="1.9.0"/>
 ```
 
 ## Step 2 — Annotate your record class

--- a/fixedformat4j-micrometer/pom.xml
+++ b/fixedformat4j-micrometer/pom.xml
@@ -5,7 +5,7 @@
   <name>Fixed Format for Java - Micrometer instrumentation</name>
   <groupId>com.ancientprogramming.fixedformat4j</groupId>
 
-  <version>1.9.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <artifactId>fixedformat4j-micrometer</artifactId>
   <packaging>jar</packaging>
 

--- a/fixedformat4j-processor/pom.xml
+++ b/fixedformat4j-processor/pom.xml
@@ -5,7 +5,7 @@
   <name>Fixed Format for Java - annotation processor</name>
   <groupId>com.ancientprogramming.fixedformat4j</groupId>
 
-  <version>1.9.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <artifactId>fixedformat4j-processor</artifactId>
   <packaging>jar</packaging>
 

--- a/fixedformat4j/pom.xml
+++ b/fixedformat4j/pom.xml
@@ -5,7 +5,7 @@
   <name>Fixed Format for Java</name>
   <groupId>com.ancientprogramming.fixedformat4j</groupId>
 
-  <version>1.9.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <artifactId>fixedformat4j</artifactId>
   <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <name>Fixed Format for Java - root</name>
   <groupId>com.ancientprogramming.fixedformat4j</groupId>
-  <version>1.9.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <artifactId>fixedformat4j-root</artifactId>
   <packaging>pom</packaging>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -5,7 +5,7 @@
   <name>Fixed Format for Java Samples</name>
   <groupId>com.ancientprogramming.fixedformat4j</groupId>
 
-  <version>1.9.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <artifactId>fixedformat4j-samples</artifactId>
   <packaging>jar</packaging>
 
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>fixedformat4j</artifactId>
-      <version>1.9.0-SNAPSHOT</version>
+      <version>2.0.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## Change

Post-release housekeeping for 1.9.0 (published 2026-06-12) and preparation for 2.0.0 development. The old `maven-publish.yml` on master could not push its post-release commits (rejected by branch protection — see #148/#149), so this PR carries that bookkeeping instead:

- **Version bump to `2.0.0-SNAPSHOT`** in all module poms (root, `fixedformat4j`, `fixedformat4j-processor`, `fixedformat4j-micrometer`, `samples` — including its dependency on the core artifact — and `benchmarks`), via `mvn versions:set -DprocessAllModules=true`. The next release is 2.0.0, superseding the workflow's computed 1.9.1. Also updates the version in the `micrometer-bench` usage example comment in `benchmarks/pom.xml`, which `versions:set` does not touch.
- **Changelog**: `## [Unreleased] 1.9.0` → `## 1.9.0 (2026-06-12)`.
- **Docs version refs**: `README.md` ("Latest release" heading and dependency snippets), `docs/get-it.md`, and `docs/quickstart.md` bumped from 1.8.x to 1.9.0.

## Breaking-change checklist

Not applicable — version metadata and docs only; no annotation surface, public interface, extension point, activation gate, or parse/export semantics are touched.

## Verification

- `grep -rn "1\.9\.0-SNAPSHOT" --include=pom.xml .` returns no matches after the change.
- The remaining `1.8.x` references in docs are historical ("since 1.8.1" feature notes and changelog entries), left intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)