### PR TITLE
docs: README example of @Field annotations on Java record components

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,27 @@ public class EmployeeRecord {
 
 Place `@Field` on the fields, let Lombok generate the getters and setters, and the result is identical.
 
+#### Using Java records instead
+
+On JDK 16+ the same mapping works as a Java `record` (since 1.9.0) — annotate the record components; no setters and no no-arg constructor are needed:
+
+```java
+@Record
+public record EmployeeRecord(
+
+    @Field(offset = 1, length = 20)
+    String name,
+
+    @Field(offset = 21, length = 6, align = Align.RIGHT, paddingChar = '0')
+    Integer employeeId,
+
+    @Field(offset = 27, length = 8)
+    @FixedFormatPattern("yyyyMMdd")
+    LocalDate hireDate) {}
+```
+
+Every annotation — `@Field`, `@Fields`, `@FixedFormatPattern`, `@FixedFormatDecimal`, `@FixedFormatNumber`, `@FixedFormatBoolean`, `@FixedFormatEnum` — applies to record components exactly as to getter methods, including nested `@Record` components and repeating fields. `load()` binds all parsed values through the canonical constructor in one call, and `export()` reads the component accessors (`record.name()`). The library itself still runs on Java 11 — record binding activates only when a record class is encountered.
+
 ### 3. Load from a string
 
 ```java


### PR DESCRIPTION
## Change

Adds a "Using Java records instead" subsection to the README's Quick start (step 2, alongside the existing POJO and Lombok variants, just after the SLF4J/dependency notes). It shows the same `EmployeeRecord` mapping expressed as a Java `record` with `@Field` / `@FixedFormatPattern` on the record components, and summarizes the semantics: all annotations apply to components exactly as to getters, `load()` binds through the canonical constructor, `export()` reads the component accessors, JDK 16+ at runtime while the library stays Java 11 compatible.

Content is consistent with the 1.9.0 changelog entry for #119 and the existing record support documentation.

## Breaking-change checklist

Not applicable — README documentation only; no code is touched.

## Verification

- Example mirrors the surrounding POJO/Lombok examples (same fields, offsets, and annotations) so the three variants stay directly comparable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)