### PR TITLE
ci: drop pre-count releases from benchmark sweep default

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -6,7 +6,7 @@ on:
       versions:
         description: "Space-separated list of versions (e.g. '1.6.1 1.8.0')"
         required: true
-        default: "1.5.0 1.6.1 1.7.2 1.8.0 master"
+        default: "1.6.1 1.7.2 1.8.1 1.9.0 master"
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
## Summary

Benchmarks run [27437481558](https://github.com/jeyben/fixedformat4j/actions/runs/27437481558) failed: the sweep included 1.5.0, but the benchmarks module now contains `RepeatingRecord`, which uses `@Field(count = 10)` — an attribute introduced in 1.6.0. Compiling the module against 1.5.0 fails with `cannot find symbol: method count()`, aborting the whole run.

Fix: refresh the `workflow_dispatch` `versions` input default from `1.5.0 1.6.1 1.7.2 1.8.0 master` to `1.6.1 1.7.2 1.8.1 1.9.0 master` — drops the pre-`count` release and picks up the current 1.8.1 / 1.9.0 releases. `benchmarks/run.sh`'s no-arg fallback already starts at 1.6.1.

No library code changes; CI config only.

## Verification

After merge, dispatch the workflow with the new default (`gh workflow run benchmarks.yml`) and confirm it goes green and opens the results PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)