### PR TITLE
docs: correct ClassValue thread-safety note in ClassMetadataCache

### DIFF
--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ClassMetadataCache.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/ClassMetadataCache.java
@@ -25,10 +25,11 @@ import static java.lang.String.format;
  * {@link FieldDescriptor} per effective {@code @Field}. Subsequent calls return the same
  * immutable list without re-scanning.
  *
- * <p>Thread safety: {@link ClassValue} guarantees that {@link #build} runs at most once per
- * class key. Helper objects ({@link AnnotationScanner}, {@link FormatInstructionsBuilder},
- * {@link RepeatingFieldSupport}) are created as local variables inside {@code build} so that
- * concurrent builds of different classes never share mutable state.
+ * <p>Thread safety: under contention {@link ClassValue} may invoke {@link #build} more than once
+ * for the same class key, but installs and returns a single value; the redundant results are
+ * discarded. This is harmless because {@code build} is pure — its helper objects
+ * ({@link AnnotationScanner}, {@link FormatInstructionsBuilder}, {@link RepeatingFieldSupport})
+ * are created as local variables, so concurrent builds never share mutable state.
  *
  * <p>Classloader safety: values are stored inside each {@link Class} object via {@link ClassValue},
  * so they are automatically eligible for GC once the defining classloader becomes unreachable.


### PR DESCRIPTION
## What

Corrects an overstated thread-safety claim in `ClassMetadataCache`'s Javadoc. The comment said:

> `ClassValue` guarantees that `build` runs at most once per class key.

`ClassValue.computeValue` may actually be invoked more than once under contention — it only guarantees that a *single* value is installed and returned. The reworded note states that redundant concurrent builds are discarded and that the real safety guarantee rests on `build()` being pure (helper objects are locals, so concurrent builds share no mutable state).

## Why

Came out of a review of whether the 1.8.1 → 1.9.0 upgrade weakened thread-safety. It did not — `FixedFormatManagerImpl` remains safe to share across threads (`ClassValue`-backed metadata cache, immutable `FieldDescriptor`/`ConstructorBinding`, stateless or `ThreadLocal`/`volatile`-guarded formatters). This comment was the only inaccuracy found.

## Scope

Comment-only change. No production behavior change; `fixedformat4j` compiles clean and the concurrency suite (`TestFixedFormatManagerConcurrency`, `TestClassMetadataCacheConcurrency`, `TestByTypeFormatter`) passes on Temurin 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)