### PR TITLE
ci(benchmarks): fail loudly on unresolvable versions

### DIFF
--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -9,6 +9,28 @@ else
   VERSIONS=("$@")
 fi
 
+# Pre-flight: every requested release (everything except "master", which is
+# built locally) must resolve from Maven Central before we run anything. A
+# version that does not resolve used to be silently skipped, so it quietly
+# vanished from the docs — e.g. a typo'd "1.9.1", or a release dispatched on
+# its release day before it had finished syncing to Central. Collect every
+# unresolvable version and fail loudly up front rather than producing a green
+# run with missing results.
+MISSING=()
+for V in "${VERSIONS[@]}"; do
+  [[ "$V" == "master" ]] && continue
+  if ! mvn dependency:get \
+       -Dartifact="com.ancientprogramming.fixedformat4j:fixedformat4j:${V}" \
+       -q >/dev/null 2>&1; then
+    MISSING+=("$V")
+  fi
+done
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+  echo "::error::Unresolvable fixedformat4j version(s): ${MISSING[*]}" >&2
+  echo "Each non-master version must exist and have finished syncing to Maven Central. Fix the version list and re-run." >&2
+  exit 1
+fi
+
 OUT_DIR="$(pwd)/docs/assets/benchmarks"
 mkdir -p "$OUT_DIR"
 
@@ -25,15 +47,6 @@ for V in "${VERSIONS[@]}"; do
   else
     TARGET_VERSION="$V"
     LABEL="$V"
-  fi
-
-  if [[ "$V" != "master" ]]; then
-    if ! mvn dependency:get \
-         -Dartifact="com.ancientprogramming.fixedformat4j:fixedformat4j:${TARGET_VERSION}" \
-         -q >/dev/null 2>&1; then
-      echo "Skipping ${LABEL}: fixedformat4j:${TARGET_VERSION} not found in Maven Central." >&2
-      continue
-    fi
   fi
 
   SHA="$(git rev-parse --short HEAD)"


### PR DESCRIPTION
## Problem

`benchmarks/run.sh` silently skipped any non-`master` version that didn't resolve from Maven Central, then continued with a **green** job. This is how 1.9.0 went missing from the published docs:

| Run | Dispatched with | Outcome |
|-----|-----------------|---------|
| Release day (`3f4fc22`) | `… 1.9.0` | 1.9.0 not yet synced to Central → **silently skipped** |
| Later (`f42ba5e`) | `… 1.9.1` | typo'd version that never existed → **silently skipped**, dir wiped & re-run with no new version |

Net result: `docs/assets/benchmarks/index.json` still lists only `1.6.1, 1.7.2, 1.8.1`.

## Change

Replace the per-version skip with an **up-front pre-flight check**:

- Resolve every requested release *before* running any benchmark.
- Collect all unresolvable versions and abort with a `::error::` annotation listing them.
- `master` is exempt (built locally).

A missing/typo'd version now **fails the job loudly** instead of vanishing from the docs.

## Verification

- `bash -n benchmarks/run.sh` — syntax OK.
- Pre-flight test with `1.9.0 1.9.1 master`: flags only `1.9.1`, ignores `master`, resolves `1.9.0`.

## Note

The actual 1.9.0 results are being backfilled by a separate dispatched Benchmarks run (not part of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)