### PR TITLE
docs(site): SEO meta tags, sitemap and per-page descriptions

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,12 @@
 title: fixedformat4j
-description: A Java API for working with fixed formatted text files
+description: >-
+  Lightweight Java library for reading and writing fixed-width / fixed-length
+  flat files using annotations on POJOs — for banking, payroll, EDI, mainframe,
+  and batch integrations.
+url: https://jeyben.github.io/fixedformat4j
+lang: en-US
 theme: jekyll-theme-cayman
+
+plugins:
+  - jekyll-seo-tag
+  - jekyll-sitemap

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
-    <title>{{ page.title | default: site.title }}</title>
+    {% seo %}
   </head>
   <body>
     <header class="page-header" role="banner">

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,6 +1,8 @@
 ---
 layout: default
 title: Benchmarks
+description: >-
+  JMH throughput benchmarks for fixedformat4j across releases, comparing parse and export performance for fixed-width records.
 ---
 
 # Benchmarks

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,7 @@
 ---
 title: Changelog
+description: >-
+  Release history and changelog for fixedformat4j, the Java fixed-width / flat-file library.
 ---
 
 # Changelog

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,5 +1,7 @@
 ---
 title: Examples
+description: >-
+  Worked examples of parsing and writing fixed-width flat files with fixedformat4j — annotations, alignment, dates, decimals and round-trip load/export.
 ---
 
 # Examples

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,7 @@
 ---
 title: FAQ
+description: >-
+  Frequently asked questions about fixedformat4j: padding, alignment, null handling, custom formatters, Java records and fixed-width file parsing in Java.
 ---
 
 # Frequently Asked Questions

--- a/docs/get-it.md
+++ b/docs/get-it.md
@@ -1,5 +1,7 @@
 ---
 title: Get fixedformat4j
+description: >-
+  Maven and Gradle coordinates for fixedformat4j and its optional annotation-processor and Micrometer modules.
 ---
 
 # Get the latest version of fixedformat4j

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,7 @@
 ---
 title: fixedformat4j
+description: >-
+  fixedformat4j is a lightweight Java library for reading and writing fixed-width / fixed-length flat files using annotations on POJOs, with built-in formatters for strings, numbers, dates and BigDecimal.
 ---
 
 # Fixedformat4j

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,5 +1,7 @@
 ---
 title: Quick Start
+description: >-
+  Get started with fixedformat4j: add the dependency, annotate a POJO with @Record and @Field, and load or export fixed-width flat-file records in a few lines of Java.
 ---
 
 # Quick Start

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://jeyben.github.io/fixedformat4j/sitemap.xml

--- a/docs/usage/annotations.md
+++ b/docs/usage/annotations.md
@@ -1,5 +1,7 @@
 ---
 title: Annotations
+description: >-
+  Reference for fixedformat4j annotations — @Record, @Field, @Fields and the supplementary number, decimal, boolean and pattern annotations for fixed-width fields.
 ---
 
 # Annotations

--- a/docs/usage/compile-time-validation.md
+++ b/docs/usage/compile-time-validation.md
@@ -1,5 +1,7 @@
 ---
 title: Compile-time validation
+description: >-
+  Catch @Field and @Record misconfigurations at build time with the optional fixedformat4j annotation processor.
 ---
 
 # Compile-time validation

--- a/docs/usage/file-processing.md
+++ b/docs/usage/file-processing.md
@@ -1,5 +1,7 @@
 ---
 title: File Processing
+description: >-
+  Read and write fixed-width flat files line by line with fixedformat4j's FixedFormatReader and FixedFormatWriter.
 ---
 
 # File Processing

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -1,5 +1,7 @@
 ---
 title: Usage
+description: >-
+  Usage guide for fixedformat4j: annotations, file processing, nested records, schema introspection, metrics and compile-time validation.
 ---
 
 # Usage

--- a/docs/usage/introspection.md
+++ b/docs/usage/introspection.md
@@ -1,5 +1,7 @@
 ---
 title: Schema introspection
+description: >-
+  Inspect the field layout of a fixedformat4j @Record at runtime via the FixedFormatIntrospector API and immutable FieldInfo descriptors.
 ---
 
 # Schema introspection

--- a/docs/usage/metrics.md
+++ b/docs/usage/metrics.md
@@ -1,5 +1,7 @@
 ---
 title: Metrics
+description: >-
+  Instrument fixedformat4j with Micrometer timers, counters and gauges using the optional fixedformat4j-micrometer module.
 ---
 
 # Metrics with Micrometer

--- a/docs/usage/nested-records.md
+++ b/docs/usage/nested-records.md
@@ -1,5 +1,7 @@
 ---
 title: Nested Records
+description: >-
+  Compose fixed-width records from nested @Record types with fixedformat4j for hierarchical flat-file layouts.
 ---
 
 # Nested Records


### PR DESCRIPTION
## Why

The Jekyll docs site (https://jeyben.github.io/fixedformat4j) emitted only a bare `<head>` — `charset`, `viewport`, `<title>`. No meta description, Open Graph, Twitter Card, canonical URL, or sitemap. That's the largest discoverability gap: Google ranking and social-share cards key off exactly those tags.

## Changes

- Enable **`jekyll-seo-tag`** + **`jekyll-sitemap`** (both on the GitHub Pages allowed-plugins list) and render `{% seo %}` in the layout `<head>`, replacing the manual `<title>`. This auto-emits meta description, canonical, Open Graph, Twitter Card and JSON-LD.
- Set `url` and a keyword-rich `description` in `_config.yml` so generated tags + `sitemap.xml` use correct absolute URLs.
- Add a **unique `description`** to every docs page's frontmatter (14 pages).
- Add `robots.txt` advertising the sitemap.

## Safety

- **No `baseurl` change** → existing `relative_url` navigation is untouched.
- All frontmatter + `_config.yml` validated with Ruby's Psych (Jekyll's own YAML parser).
- Plugins are GitHub Pages-whitelisted, so the Pages build will pick them up on merge.

## Verify after merge

- View source on any docs page → confirm `<meta name="description">`, `og:*`, `twitter:*`, canonical link present.
- `https://jeyben.github.io/fixedformat4j/sitemap.xml` resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)