### PR TITLE
fix: allow custom formatters on enum fields (#161) — 1.7.3

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,32 @@ title: Changelog
 
 # Changelog
 
+## 1.7.3 (2026-06-17)
+
+### Bug fixes
+
+- **Custom `formatter=` on enum fields no longer triggers the enum length check** ([#161](https://github.com/jeyben/fixedformat4j/issues/161)) —
+  The enum field-length validation added in 1.7.0 measured the longest enum `name()`
+  (LITERAL) or the ordinal digit count (NUMERIC) and threw `FixedFormatException` when that
+  exceeded `@Field(length)`. That premise only holds for the built-in `EnumFormatter`. When a
+  field declares its own `formatter=`, the enum's name/ordinal is irrelevant — the custom
+  formatter emits its own representation (e.g. a single-character code) — yet the check still
+  fired and blocked `load`/`export`.
+
+  The validation is now skipped whenever a non-default formatter is declared, because the
+  framework cannot statically know the custom output length.
+
+  ```java
+  // 12-constant enum, each mapped to a single-character code, in a length-1 field.
+  // Previously threw "max length 35 … exceeds @Field length 1"; now loads/exports correctly.
+  @Field(offset = 57, length = 1, formatter = NsccTransactionType.Formatter.class)
+  public NsccTransactionType getNsccTransactionType() { … }
+  ```
+
+  This loosens an activation gate but only ever *removes* a hard error, so it is strictly more
+  permissive: records that previously worked are unaffected, round-trip fidelity is preserved,
+  and the default-formatter enum length check is unchanged. No migration required.
+
 ## 1.7.2 (2026-04-20)
 
 ### Behaviour changes

--- a/fixedformat4j/pom.xml
+++ b/fixedformat4j/pom.xml
@@ -5,7 +5,7 @@
   <name>Fixed Format for Java</name>
   <groupId>com.ancientprogramming.fixedformat4j</groupId>
 
-  <version>1.7.2</version>
+  <version>1.7.3</version>
   <artifactId>fixedformat4j</artifactId>
   <packaging>jar</packaging>
 

--- a/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
+++ b/fixedformat4j/src/main/java/com/ancientprogramming/fixedformat4j/format/impl/FixedFormatManagerImpl.java
@@ -189,6 +189,9 @@ public class FixedFormatManagerImpl implements FixedFormatManager {
 
   @SuppressWarnings({"unchecked", "rawtypes"})
   private void validateEnumFieldLength(AnnotationTarget target, Field fieldAnnotation) {
+    if (fieldAnnotation.formatter() != ByTypeFormatter.class) {
+      return;
+    }
     FormatInstructionsBuilder instructionsBuilder = new FormatInstructionsBuilder();
     Class<?> datatype = instructionsBuilder.datatype(target.getter, fieldAnnotation);
     if (!datatype.isEnum()) {

--- a/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/issues/TestIssue161CustomEnumFormatter.java
+++ b/fixedformat4j/src/test/java/com/ancientprogramming/fixedformat4j/issues/TestIssue161CustomEnumFormatter.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2004 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ancientprogramming.fixedformat4j.issues;
+
+import com.ancientprogramming.fixedformat4j.annotation.Field;
+import com.ancientprogramming.fixedformat4j.annotation.Record;
+import com.ancientprogramming.fixedformat4j.exception.FixedFormatException;
+import com.ancientprogramming.fixedformat4j.format.AbstractFixedFormatter;
+import com.ancientprogramming.fixedformat4j.format.FixedFormatManager;
+import com.ancientprogramming.fixedformat4j.format.FormatInstructions;
+import com.ancientprogramming.fixedformat4j.format.impl.FixedFormatManagerImpl;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for Issue 161 — custom formatters on enum fields.
+ *
+ * <p>Before the fix, {@code validateEnumFieldLength} measured the longest enum
+ * {@code name()} (LITERAL) or the ordinal digit count (NUMERIC) and rejected the field
+ * when that exceeded {@code @Field(length)}, regardless of any custom {@code formatter=}.
+ * That premise only holds for the built-in {@code EnumFormatter}; a custom formatter emits
+ * its own representation, so the length check is meaningless and must be skipped.
+ *
+ * <p>The fixtures reproduce the reporter's exact scenario: a 12-constant enum whose names are
+ * far longer than one character, each mapped to a single-character code, declared with
+ * {@code length = 1}. Neither built-in {@code EnumFormat} mode can satisfy length 1 (LITERAL
+ * overflows on the names, NUMERIC needs two digits for 12 constants), so only a custom
+ * formatter works.
+ */
+public class TestIssue161CustomEnumFormatter {
+
+  private final FixedFormatManager manager = new FixedFormatManagerImpl();
+
+  // -------------------------------------------------------------------------
+  // Reporter's enum + custom formatter (Guava BiMap replaced with plain maps)
+  // -------------------------------------------------------------------------
+
+  enum NsccTransactionType {
+    SINGLE_PURCHASE("0"),
+    LETTER_OF_INTENT("1"),
+    RIGHTS_OF_ACCUMULATION("2"),
+    NET_ASSET_VALUE("3"),
+    GROUP_PURCHASE("4"),
+    CDSC_LIQUIDATION("5"),
+    PARTICIPANT_DISTRIBUTION_529("8"),
+    BENEFICIARY_DISTRIBUTION_529("9"),
+    SCHOOL_DISTRIBUTION_529("A"),
+    ROLLOVER_DISTRIBUTION_529("B"),
+    IN_STATE_PLAN_TRANSFER_DISTRIBUTION("E"),
+    REGISTRATION_CHANGE_529("F");
+
+    private final String value;
+
+    NsccTransactionType(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    public static class Formatter extends EnumFixedFormatter<NsccTransactionType> {
+      public Formatter() {
+        super(NsccTransactionType.class, NsccTransactionType::getValue);
+      }
+    }
+  }
+
+  abstract static class EnumFixedFormatter<T extends Enum<T>> extends AbstractFixedFormatter<T> {
+
+    private final Map<T, String> enumToValue = new HashMap<>();
+    private final Map<String, T> valueToEnum = new HashMap<>();
+
+    protected EnumFixedFormatter(Class<T> enumClass, Function<T, String> valueFunction) {
+      for (T constant : enumClass.getEnumConstants()) {
+        String code = valueFunction.apply(constant);
+        if (valueToEnum.put(code, constant) != null) {
+          throw new IllegalArgumentException("Duplicate code: " + code);
+        }
+        enumToValue.put(constant, code);
+      }
+    }
+
+    @Override
+    public T asObject(String value, FormatInstructions instructions) {
+      return valueToEnum.get(value);
+    }
+
+    @Override
+    public String asString(T obj, FormatInstructions instructions) {
+      return enumToValue.get(obj);
+    }
+  }
+
+  @Record(length = 1)
+  public static class CustomFormatterRecord {
+    private NsccTransactionType nsccTransactionType;
+
+    @Field(offset = 1, length = 1, formatter = NsccTransactionType.Formatter.class)
+    public NsccTransactionType getNsccTransactionType() {
+      return nsccTransactionType;
+    }
+
+    public void setNsccTransactionType(NsccTransactionType nsccTransactionType) {
+      this.nsccTransactionType = nsccTransactionType;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Tests
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void customFormatterEnumField_loadsSingleCharCode() {
+    CustomFormatterRecord record = manager.load(CustomFormatterRecord.class, "A");
+    assertEquals(NsccTransactionType.SCHOOL_DISTRIBUTION_529, record.getNsccTransactionType());
+  }
+
+  @Test
+  public void customFormatterEnumField_exportsSingleCharCode() {
+    CustomFormatterRecord record = new CustomFormatterRecord();
+    record.setNsccTransactionType(NsccTransactionType.REGISTRATION_CHANGE_529);
+    assertEquals("F", manager.export(record));
+  }
+
+  @Test
+  public void customFormatterEnumField_roundTripsConstantBeyondNinthOrdinal() {
+    CustomFormatterRecord record = new CustomFormatterRecord();
+    record.setNsccTransactionType(NsccTransactionType.IN_STATE_PLAN_TRANSFER_DISTRIBUTION);
+    String exported = manager.export(record);
+    assertEquals("E", exported);
+    assertEquals(
+        NsccTransactionType.IN_STATE_PLAN_TRANSFER_DISTRIBUTION,
+        manager.load(CustomFormatterRecord.class, exported).getNsccTransactionType());
+  }
+
+  // -------------------------------------------------------------------------
+  // Guard: the default (no custom formatter) enum path still validates length
+  // -------------------------------------------------------------------------
+
+  enum TooLongForField {
+    VERY_LONG_ENUM_VALUE_NAME, ANOTHER_VALUE
+  }
+
+  @Record(length = 1)
+  public static class DefaultFormatterTooShortRecord {
+    private TooLongForField value;
+
+    @Field(offset = 1, length = 1)
+    public TooLongForField getValue() {
+      return value;
+    }
+
+    public void setValue(TooLongForField value) {
+      this.value = value;
+    }
+  }
+
+  @Test
+  public void defaultFormatterEnumNameTooLong_stillThrows() {
+    FixedFormatException ex = assertThrows(FixedFormatException.class,
+        () -> manager.load(DefaultFormatterTooShortRecord.class, "X"));
+    assertTrue(ex.getMessage().contains("max length"),
+        "exception should mention max length: " + ex.getMessage());
+  }
+
+  // Sanity: the reporter's enum genuinely defeats both built-in EnumFormat modes at length 1.
+  @Test
+  public void reporterEnumDefeatsBothBuiltinModes() {
+    int longestName = Arrays.stream(NsccTransactionType.values())
+        .mapToInt(e -> e.name().length()).max().orElse(0);
+    int numericWidth = String.valueOf(NsccTransactionType.values().length - 1).length();
+    assertTrue(longestName > 1, "LITERAL would overflow length 1");
+    assertTrue(numericWidth > 1, "NUMERIC would overflow length 1");
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <name>Fixed Format for Java - root</name>
   <groupId>com.ancientprogramming.fixedformat4j</groupId>
-  <version>1.7.2</version>
+  <version>1.7.3</version>
   <artifactId>fixedformat4j-root</artifactId>
   <packaging>pom</packaging>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -5,7 +5,7 @@
   <name>Fixed Format for Java Samples</name>
   <groupId>com.ancientprogramming.fixedformat4j</groupId>
 
-  <version>1.7.2</version>
+  <version>1.7.3</version>
   <artifactId>fixedformat4j-samples</artifactId>
   <packaging>jar</packaging>
 
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>fixedformat4j</artifactId>
-      <version>1.7.2</version>
+      <version>1.7.3</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## Summary

Fixes #161. The enum field-length validation added in 1.7.0 rejected valid records whenever an enum field declared a custom `formatter=`. It measured the longest enum `name()` (LITERAL) or the ordinal digit count (NUMERIC) and threw `FixedFormatException` when that exceeded `@Field(length)` — but that premise only holds for the built-in `EnumFormatter`. A custom formatter emits its own representation (the reporter maps a 12-constant enum to single-character codes in a `length = 1` field), so the check was meaningless yet blocked `load`/`export`.

The fix skips the validation whenever a non-default formatter is declared (`fieldAnnotation.formatter() != ByTypeFormatter.class`), because the framework cannot statically know the custom output length.

Targets the new `1_7_bugfix` maintenance branch (cut from the `1_7_2` tag) for a **1.7.3** release.

## Framework-breaking-change checklist

This touches an **activation gate** and **parse/export semantics**, so per `CLAUDE.md`:

- **What breaks:** nothing for existing working records. The change only *removes* a hard error. Concretely: `@Field(length = 1, formatter = MyEnumFormatter.class)` on an enum whose longest name is 35 chars previously threw `"max length 35 … exceeds @Field length 1"`; it now loads/exports through the custom formatter.
- **Who's affected:** only consumers who were *blocked* by the false-positive validation. No consumer relied on the throw as intended behavior.
- **Round-trip impact:** `load(export(x)) == x` still holds; the default-formatter enum length check is unchanged.
- **Migration:** none required. Strictly more permissive.

## Tests (TDD)

New regression test `TestIssue161CustomEnumFormatter` reproduces the reporter's exact `NsccTransactionType` example (12 constants → single-char codes, `length = 1`, custom formatter extending `AbstractFixedFormatter`; Guava `BiMap` swapped for plain `Map`s to avoid a test dependency):

- Confirmed RED on unmodified code (the 3 custom-formatter tests threw the #161 error).
- GREEN after the fix: load (`"A"` → `SCHOOL_DISTRIBUTION_529`), export (`REGISTRATION_CHANGE_529` → `"F"`), and round-trip of a constant beyond the 9th ordinal.
- A guard test pins that the **default**-formatter enum path still throws when a name overflows the field.
- A sanity test asserts the reporter's enum defeats both built-in `EnumFormat` modes at `length = 1`.

Full multi-module build green at 1.7.3 (452 tests, `mvn install`).

## Changes

- `FixedFormatManagerImpl.validateEnumFieldLength` — early return when a custom formatter is declared.
- Version bump `1.7.2` → `1.7.3` (root, `fixedformat4j`, `samples` self + dependency).
- `docs/changelog.md` — 1.7.3 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)