### PR TITLE
ci: deploy the released tag instead of master (1.9.x release workflow)

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,12 +1,25 @@
 name: Publish to Maven Central
 
+# master is protected (required status check "build"), so this workflow never
+# pushes to master (#148). The release flow is:
+#
+#   1. Release-prep PR (human): set poms to the release version, date the
+#      changelog, update docs version refs. Merge via the normal PR flow.
+#   2. Publish a GitHub release with tag X_Y_Z on the merged commit. This
+#      workflow checks out the tag, verifies the pom version matches, deploys
+#      to Maven Central, and uploads the artifacts to the release.
+#   3. The workflow opens a PR bumping master to the next -SNAPSHOT version.
+#
+# workflow_dispatch redeploys an existing release tag (e.g. after a transient
+# deploy failure); it does not upload release assets or open the bump PR.
+
 on:
   release:
     types: [published]
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (e.g. 1.5.0)'
+        description: 'Released version to redeploy (e.g. 1.9.0) — tag X_Y_Z must exist'
         required: true
 
 env:
@@ -15,15 +28,13 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
-      contents: write
+      contents: write       # upload release assets, push the snapshot-bump branch
+      pull-requests: write  # open the snapshot-bump PR
+      actions: write        # dispatch nightly-build.yml on the bump branch
 
     steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: master
-          fetch-depth: 0
-
       - name: Validate version input
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -33,6 +44,10 @@ jobs:
             echo "::error::Invalid version format '$VERSION_INPUT' — expected X.Y.Z (e.g. 1.5.0)"
             exit 1
           fi
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 11
         uses: actions/setup-java@v5
@@ -45,50 +60,31 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Configure git signing
-        env:
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: |
-          GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format LONG \
-            | grep '^sec' | head -1 | awk '{print $2}' | cut -d/ -f2)
-          echo "$MAVEN_GPG_PASSPHRASE" | gpg --batch --yes --pinentry-mode loopback \
-            --passphrase-fd 0 --sign --output /dev/null /dev/null 2>/dev/null || true
-          git config user.signingkey "$GPG_KEY_ID"
-          git config commit.gpgsign true
-          git config tag.gpgsign true
-          echo "GPG_KEY_ID=$GPG_KEY_ID" >> $GITHUB_ENV
-
-      - name: Resolve release version
+      - name: Resolve release version and check out tag
         env:
           VERSION_INPUT: ${{ inputs.version }}
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           if [ -n "$VERSION_INPUT" ]; then
             VERSION="$VERSION_INPUT"
+            TAG=$(echo "$VERSION" | tr '.' '_')
           else
-            VERSION=$(echo "${GITHUB_REF_NAME}" | tr '_' '.')
+            TAG="$RELEASE_TAG_NAME"
+            VERSION=$(echo "$TAG" | tr '_' '.')
           fi
+          git checkout "$TAG"
           echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+          echo "RELEASE_TAG=$TAG" >> $GITHUB_ENV
 
-      - name: Set release version in poms
+      - name: Verify pom versions match the release
         run: |
-          mvn -B versions:set -DnewVersion=$RELEASE_VERSION -DprocessAllModules=true -DgenerateBackupPoms=false
-          git add -A
-          git diff --staged --quiet || git commit -m "Release $RELEASE_VERSION"
-
-      - name: Create signed release tag
-        if: github.event_name == 'release'
-        env:
-          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: |
-          git tag -d "${{ github.event.release.tag_name }}" 2>/dev/null || true
-          git tag -s "${{ github.event.release.tag_name }}" \
-            -m "Release $RELEASE_VERSION"
-          git push --force origin "${{ github.event.release.tag_name }}"
+          for MODULE in fixedformat4j fixedformat4j-processor fixedformat4j-micrometer; do
+            MODULE_VERSION=$(mvn -B -q -f "$MODULE/pom.xml" help:evaluate -Dexpression=project.version -DforceStdout)
+            if [ "$MODULE_VERSION" != "$RELEASE_VERSION" ]; then
+              echo "::error::$MODULE/pom.xml version is $MODULE_VERSION but the release is $RELEASE_VERSION — merge the release-prep PR setting all module poms to $RELEASE_VERSION before publishing"
+              exit 1
+            fi
+          done
 
       - name: Deploy to Maven Central
         env:
@@ -100,23 +96,42 @@ jobs:
       - name: Upload release artifacts to GitHub
         if: github.event_name == 'release'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload ${{ github.event.release.tag_name }} \
-            fixedformat4j/target/fixedformat4j-${{ env.RELEASE_VERSION }}.jar \
-            fixedformat4j/target/fixedformat4j-${{ env.RELEASE_VERSION }}-sources.jar \
-            fixedformat4j/target/fixedformat4j-${{ env.RELEASE_VERSION }}-javadoc.jar \
-            fixedformat4j-processor/target/fixedformat4j-processor-${{ env.RELEASE_VERSION }}.jar \
-            fixedformat4j-processor/target/fixedformat4j-processor-${{ env.RELEASE_VERSION }}-sources.jar \
-            fixedformat4j-processor/target/fixedformat4j-processor-${{ env.RELEASE_VERSION }}-javadoc.jar \
-            fixedformat4j-micrometer/target/fixedformat4j-micrometer-${{ env.RELEASE_VERSION }}.jar \
-            fixedformat4j-micrometer/target/fixedformat4j-micrometer-${{ env.RELEASE_VERSION }}-sources.jar \
-            fixedformat4j-micrometer/target/fixedformat4j-micrometer-${{ env.RELEASE_VERSION }}-javadoc.jar
+          gh release upload --clobber "$RELEASE_TAG" \
+            "fixedformat4j/target/fixedformat4j-$RELEASE_VERSION.jar" \
+            "fixedformat4j/target/fixedformat4j-$RELEASE_VERSION-sources.jar" \
+            "fixedformat4j/target/fixedformat4j-$RELEASE_VERSION-javadoc.jar" \
+            "fixedformat4j-processor/target/fixedformat4j-processor-$RELEASE_VERSION.jar" \
+            "fixedformat4j-processor/target/fixedformat4j-processor-$RELEASE_VERSION-sources.jar" \
+            "fixedformat4j-processor/target/fixedformat4j-processor-$RELEASE_VERSION-javadoc.jar" \
+            "fixedformat4j-micrometer/target/fixedformat4j-micrometer-$RELEASE_VERSION.jar" \
+            "fixedformat4j-micrometer/target/fixedformat4j-micrometer-$RELEASE_VERSION-sources.jar" \
+            "fixedformat4j-micrometer/target/fixedformat4j-micrometer-$RELEASE_VERSION-javadoc.jar"
 
-      - name: Bump to next snapshot version
+      - name: Open PR bumping the bugfix branch to next snapshot version
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_BRANCH: ${{ github.event.release.target_commitish }}
         run: |
-          NEXT=$(echo $RELEASE_VERSION | awk -F. '{print $1"."$2"."$3+1"-SNAPSHOT"}')
-          mvn -B versions:set -DnewVersion=$NEXT -DprocessAllModules=true -DgenerateBackupPoms=false
-          git add -A
-          git commit -m "Prepare $NEXT development"
-          git push origin master
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          NEXT=$(echo "$RELEASE_VERSION" | awk -F. '{print $1"."$2"."$3+1"-SNAPSHOT"}')
+          BRANCH="chore/prepare-$NEXT-${{ github.run_id }}-${{ github.run_attempt }}"
+          git checkout -B "$BRANCH" "origin/$RELEASE_BRANCH"
+          mvn -B versions:set --no-transfer-progress -DnewVersion="$NEXT" -DprocessAllModules=true -DgenerateBackupPoms=false
+          if git diff --quiet; then
+            echo "$RELEASE_BRANCH is already at $NEXT; nothing to bump."
+            exit 0
+          fi
+          git commit -am "Prepare $NEXT development"
+          git push origin "$BRANCH"
+          gh pr create \
+            --base "$RELEASE_BRANCH" \
+            --head "$BRANCH" \
+            --title "Prepare $NEXT development" \
+            --body "$(printf 'Automated post-release version bump after publishing %s.\n\nSets all module poms to %s.' "$RELEASE_VERSION" "$NEXT")"
+          # Pushes made with GITHUB_TOKEN do not trigger other workflows, so
+          # the required "build" check must be dispatched explicitly.
+          gh workflow run nightly-build.yml --ref "$BRANCH"


### PR DESCRIPTION
## Summary

Follow-up to the #161 forward-port (#169). `1_9_bugfix` (cut from the `1_9_0` tag) still carries 1_9_0's pre-#148 `maven-publish.yml` with `ref: master` and `git push origin master`. A `release` event runs the workflow from the released tag's tree, so publishing 1.9.1 with this file would deploy **master's code as 1.9.1** — the same failure that corrupted 1.7.3.

This ports master's corrected design (PR #148) onto the 1.9.x line. Unlike the 1.7/1.8 fixes (#164/#165, single module), the 1.9 line keeps **all three** deployable modules.

## Changes

The new file is master's `maven-publish.yml` **verbatim**, with one adaptation: the post-release snapshot-bump PR targets the originating bugfix branch instead of master. `git diff` against master shows only:

- `env: RELEASE_BRANCH: ${{ github.event.release.target_commitish }}`
- `git checkout -B "$BRANCH" origin/master` → `"origin/$RELEASE_BRANCH"`
- `--base master` → `--base "$RELEASE_BRANCH"`
- the "already at" echo + step title wording

Everything else is identical to the blessed master workflow: checks out the release **tag**, verifies the pom version of `fixedformat4j` + `fixedformat4j-processor` + `fixedformat4j-micrometer`, deploys all three with `-P release`, uploads their jars, supports `workflow_dispatch` redeploy, and dispatches `nightly-build.yml` for the required `build` check.

## Verification

- YAML parses cleanly.
- `git diff origin/master -- .github/workflows/maven-publish.yml` is limited to the five bump-step lines above — the 3-module verify/deploy/upload is byte-for-byte master's.
- Proof at the 1.9.1 release: the run checks out the `1_9_1` tag, verifies all three poms at 1.9.1, deploys the three artifacts to Central, and opens the snapshot-bump PR against `1_9_bugfix`.

## Notes

CI-only; no library code. Independent of #169 (disjoint files; either can merge first). **Merge before publishing any 1.9.1 release.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)